### PR TITLE
[186844118] Trims variable text after input before storing them

### DIFF
--- a/src/components/model/name-label-input.tsx
+++ b/src/components/model/name-label-input.tsx
@@ -29,13 +29,15 @@ export const NameLabelInput = ({variableIdx, variableName,
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
-      handleEditVariable(variableIdx, text);
+      const trimText = text.trim();
+      handleEditVariable(variableIdx, trimText);
       onBlur();
     }
   };
 
   const handleBlur = () => {
-    handleEditVariable(variableIdx, text);
+    const trimText = text.trim();
+    handleEditVariable(variableIdx, trimText);
     onBlur();
   };
 


### PR DESCRIPTION
In the spinner, we were not trimming leading and trailing spaces. So if you type leading or trailing spaces for a variable label that is the same as another wedge, it doesn't match and it doesn't merge the two variables.
This trims any spaces, and matching variables now merge into a single wedge.