### PR TITLE
[186869626] Extend tab border to the right on overflow 

### DIFF
--- a/src/components/App.scss
+++ b/src/components/App.scss
@@ -26,7 +26,8 @@
   &:after {
     content: "";
     border-bottom: solid 1px #777;
-    width: 100%;
+    min-width: 100%;
+    width: var(--after-width, auto);
     z-index: 1;
     bottom: 0;
     left: 0;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -20,7 +20,8 @@ const kInitialDimensions = {
   height: 500
 };
 const kDefaultVars: IVariables = ["a", "a", "b"];
-
+const kMinColumnWidth = 220; // device + gap width
+const kSelectedSamplesDivWidth = 65; //includes margin-right
 
 const navTabs = ["Model", "Measures", "About"] as const;
 type NavTab = typeof navTabs[number];
@@ -41,6 +42,9 @@ export const App = () => {
   const lastColumn = model.columns[numColumns - 1];
   const numDevicesInLastColumn = lastColumn?.devices?.length;
   const lastDeviceId = lastColumn?.devices?.[numDevicesInLastColumn - 1].id;
+  const modelWidth = (model.columns.length * kMinColumnWidth) + kSelectedSamplesDivWidth;
+  const modelHeaderStyle = {width: modelWidth};
+  const navTabsEl = document.getElementsByClassName("navigationTabs")[0] as HTMLElement;
 
   useEffect(() => {
     initializePlugin({pluginName: kPluginName, version: kVersion, dimensions: kInitialDimensions});
@@ -54,6 +58,12 @@ export const App = () => {
   useEffect(()=>{
     setSelectedDeviceId(lastDeviceId);
   }, [lastDeviceId]);
+
+  useEffect(() => {
+    if (navTabsEl && modelWidth) {
+      navTabsEl.style.setProperty("--after-width", `${modelWidth + 25}px`);
+    }
+  },[modelWidth, navTabsEl]);
 
   const handleTabSelect = (tab: NavTab) => {
     setSelectedTab(tab);
@@ -332,6 +342,7 @@ export const App = () => {
             sampleSize={sampleSize}
             numSamples={numSamples}
             enableRunButton={enableRunButton}
+            modelHeaderStyle={modelHeaderStyle}
             addDevice={handleAddDevice}
             mergeDevices={handleMergeDevices}
             deleteDevice={handleDeleteDevice}

--- a/src/components/model/model-component.scss
+++ b/src/components/model/model-component.scss
@@ -1,5 +1,5 @@
 $teal-dark: #177991;
-$pluginMinWidth: 328px;
+$pluginMinWidth: 304px;
 
 .model-tab {
   position: relative;

--- a/src/components/model/model-component.tsx
+++ b/src/components/model/model-component.tsx
@@ -8,9 +8,6 @@ import { ModelHeader } from "./model-header";
 
 import "./model-component.scss";
 
-const kMinColumnWidth = 220; // device + gap width
-const kSelectedSamplesDivWidth = 65; //includes margin-right
-
 interface IProps {
   model: IModel;
   selectedDeviceId?: Id;
@@ -18,6 +15,7 @@ interface IProps {
   sampleSize: string;
   numSamples: string;
   enableRunButton: boolean;
+  modelHeaderStyle: React.CSSProperties;
   setSelectedDeviceId: (id: Id) => void;
   addDevice: (parentDevice: IDevice) => void;
   mergeDevices: (device: IDevice) => void;
@@ -37,7 +35,7 @@ interface IProps {
   handleEditVarPct: (variableIdx: number, pctStr: string, updateNext?: boolean) => void;
 }
 
-export const ModelTab = ({ model, selectedDeviceId, repeat, sampleSize, numSamples, enableRunButton,
+export const ModelTab = ({ model, selectedDeviceId, repeat, sampleSize, numSamples, enableRunButton, modelHeaderStyle,
     addDevice, mergeDevices, deleteDevice, setSelectedDeviceId, handleNameChange,handleStartRun,
     handleUpdateCollectorVariables, handleSampleSizeChange, handleNumSamplesChange, handleSelectRepeat,
     handleSelectReplacement, handleClearData, handleAddVariable, handleDeleteVariable, handleUpdateViewType,
@@ -59,7 +57,6 @@ export const ModelTab = ({ model, selectedDeviceId, repeat, sampleSize, numSampl
     setShowHelp(!showHelp);
   };
 
-  const modelHeaderStyle = {width: (model.columns.length * kMinColumnWidth) + kSelectedSamplesDivWidth};
 
   return (
     <div className="model-tab">


### PR DESCRIPTION
Fixes tab border width not extending to the right when there is an overflow-x and user scrolls to the right.