### PR TITLE
Sampler animates while running (PT-186764176)

### DIFF
--- a/src/components/App.scss
+++ b/src/components/App.scss
@@ -5,7 +5,7 @@
   font-size: 11px;
 
   button {
-    &:hover:not(.disabled) {
+    &:hover:not(:disabled):not(.disabled) {
       cursor: pointer;
     }
   }

--- a/src/components/model/arrow.scss
+++ b/src/components/model/arrow.scss
@@ -36,6 +36,9 @@
       background-color: white;
       border-radius: 1.5px;
       border: solid 1px #8f8f9d;
+      &.disabled {
+        cursor: default;
+      }
     }
   }
 }

--- a/src/components/model/arrow.tsx
+++ b/src/components/model/arrow.tsx
@@ -2,9 +2,9 @@ import React, { useEffect, useRef, useState } from "react";
 import { useGlobalStateContext } from "../../hooks/useGlobalState";
 import { IDevice } from "../../models/device-model";
 import { useResizer } from "../../hooks/use-resizer";
+import { FormulaEditor } from "./formula-editor";
 
 import "./arrow.scss";
-import { FormulaEditor } from "./formula-editor";
 
 interface IPoint {
   x: number
@@ -46,7 +46,7 @@ const getRect = (el: HTMLElement): Rect => {
 
 export const Arrow = ({source, target, columnIndex, selectedDeviceId}: IProps) => {
   const { globalState, setGlobalState } = useGlobalStateContext();
-  const { model, modelIsRunning, numSamples } = globalState;
+  const { model, isRunning, numSamples } = globalState;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [drawCount, setDrawCount] = useState(0);
   const redraw = () => setDrawCount(prev => prev + 1);
@@ -80,7 +80,7 @@ export const Arrow = ({source, target, columnIndex, selectedDeviceId}: IProps) =
     redraw();
   }, [model, selectedDeviceId]);
 
-  useEffect(() => {setRunAnimation(modelIsRunning);}, [modelIsRunning]);
+  useEffect(() => {setRunAnimation(isRunning);}, [isRunning]);
 
   // when the plugin is resized or the scrollbar appears/disappears redraw since the arrow is absolutely positioned
   useResizer(redraw);
@@ -121,9 +121,6 @@ export const Arrow = ({source, target, columnIndex, selectedDeviceId}: IProps) =
           } else {
             setRunAnimation(false);
             numAnimationCycles.current = 0;
-            setGlobalState(draft => {
-              draft.modelIsRunning = false;
-            });
           }
         }
       };

--- a/src/components/model/column-header.tsx
+++ b/src/components/model/column-header.tsx
@@ -12,7 +12,7 @@ interface IProps {
 
 export const ColumnHeader = ({column, columnIndex}: IProps) => {
   const { globalState, setGlobalState } = useGlobalStateContext();
-  const { model } = globalState;
+  const { model, isRunning } = globalState;
   const [columnName, setColumnName] = useState(column.name);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -63,6 +63,7 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
     <div className="device-column-header">
       <input
         ref={inputRef}
+        disabled={isRunning}
         className="attr-name"
         value={columnName}
         onChange={(e) => setColumnName(e.target.value)}

--- a/src/components/model/device-footer.scss
+++ b/src/components/model/device-footer.scss
@@ -11,7 +11,6 @@
     border-radius: 1.5px;
     border: solid 1px #008cba;
     background-color: #dbf6ff;
-    cursor: pointer;
   }
 }
 .device-buttons {

--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -21,7 +21,7 @@ interface IDeviceFooter {
 
 export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handleDeleteVariable, handleSelectDataContext, handleSpecifyVariables, dataContexts}: IDeviceFooter) => {
   const { globalState, setGlobalState } = useGlobalStateContext();
-  const { model, selectedDeviceId } = globalState;
+  const { model, selectedDeviceId, isRunning } = globalState;
   const { viewType } = device;
   const targetDevices = getTargetDevices(model, device);
   const siblingDevices = getSiblingDevices(model, device);
@@ -115,9 +115,9 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
     <div className="footer">
       { viewType !== ViewType.Collector &&
         <div className="add-remove-variables-buttons">
-          <button onClick={handleAddVariable}>+</button>
-          <button onClick={(e) => handleDeleteVariable(e)}>-</button>
-          <button onClick={handleSpecifyVariables}>...</button>
+          <button disabled={isRunning} onClick={handleAddVariable}>+</button>
+          <button disabled={isRunning} onClick={(e) => handleDeleteVariable(e)}>-</button>
+          <button disabled={isRunning} onClick={handleSpecifyVariables}>...</button>
         </div>
       }
       <div className="device-buttons">
@@ -128,6 +128,7 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
               return (
                 <button
                   className={viewType === deviceType ? "selected" : ""}
+                  disabled={isRunning}
                   onClick={() => handleUpdateViewType(deviceType)}
                   key={deviceType}>
                     {deviceType}
@@ -140,7 +141,7 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
       <div className="device-buttons">
         {
           viewType === ViewType.Collector ?
-            <select onChange={handleSelectDataContext}>
+            <select disabled={isRunning} onChange={handleSelectDataContext}>
               <option value="">Select a data context</option>
               {
                 dataContexts.map((context) => {
@@ -150,8 +151,8 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
             </select>
             :
             <>
-              <button onClick={handleAddDevice}>{addButtonLabel}</button>
-              {showMergeButton && <button onClick={handleMergeDevices}>Merge</button>}
+              <button disabled={isRunning} onClick={handleAddDevice}>{addButtonLabel}</button>
+              {showMergeButton && <button disabled={isRunning} onClick={handleMergeDevices}>Merge</button>}
             </>
         }
       </div>

--- a/src/components/model/device-views/collector.tsx
+++ b/src/components/model/device-views/collector.tsx
@@ -2,19 +2,15 @@ import React, { useEffect, useState } from "react";
 import { ClippingDef, IDevice } from "../../../models/device-model";
 import { MixerFrame } from "./shared/mixer-frame";
 import { Balls } from "./shared/balls";
-import { Speed } from "../../../types";
 
 interface ICollector {
   device: IDevice;
-  isRunning: boolean;
-  speed: Speed;
   handleAddDefs: (def: ClippingDef) => void
   handleSetSelectedVariable: (variableIdx: number) => void;
   handleSetEditingVarName: (variableIdx: number) => void;
 }
 
-export const Collector = ({device, isRunning, speed, handleAddDefs,
-  handleSetSelectedVariable, handleSetEditingVarName}: ICollector) => {
+export const Collector = ({device, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName}: ICollector) => {
   const [ballsArray, setBallsArray] = useState<Array<string>>([]);
   const { collectorVariables, id: deviceId } = device;
 
@@ -33,8 +29,6 @@ export const Collector = ({device, isRunning, speed, handleAddDefs,
         <Balls
           ballsArray={ballsArray}
           deviceId={deviceId}
-          isRunning={isRunning}
-          speed={speed}
           handleAddDefs={handleAddDefs}
           handleSetSelectedVariable={handleSetSelectedVariable}
           handleSetEditingVarName={handleSetEditingVarName}

--- a/src/components/model/device-views/collector.tsx
+++ b/src/components/model/device-views/collector.tsx
@@ -2,15 +2,19 @@ import React, { useEffect, useState } from "react";
 import { ClippingDef, IDevice } from "../../../models/device-model";
 import { MixerFrame } from "./shared/mixer-frame";
 import { Balls } from "./shared/balls";
+import { Speed } from "../../../types";
 
 interface ICollector {
   device: IDevice;
+  isRunning: boolean;
+  speed: Speed;
   handleAddDefs: (def: ClippingDef) => void
   handleSetSelectedVariable: (variableIdx: number) => void;
   handleSetEditingVarName: (variableIdx: number) => void;
 }
 
-export const Collector = ({device, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName}: ICollector) => {
+export const Collector = ({device, isRunning, speed, handleAddDefs,
+  handleSetSelectedVariable, handleSetEditingVarName}: ICollector) => {
   const [ballsArray, setBallsArray] = useState<Array<string>>([]);
   const { collectorVariables, id: deviceId } = device;
 
@@ -29,6 +33,8 @@ export const Collector = ({device, handleAddDefs, handleSetSelectedVariable, han
         <Balls
           ballsArray={ballsArray}
           deviceId={deviceId}
+          isRunning={isRunning}
+          speed={speed}
           handleAddDefs={handleAddDefs}
           handleSetSelectedVariable={handleSetSelectedVariable}
           handleSetEditingVarName={handleSetEditingVarName}

--- a/src/components/model/device-views/collector.tsx
+++ b/src/components/model/device-views/collector.tsx
@@ -24,7 +24,7 @@ export const Collector = ({device, handleAddDefs, handleSetSelectedVariable, han
 
   return (
     <>
-      <MixerFrame withReplacement={false}/>
+      <MixerFrame/>
       { ballsArray.length &&
         <Balls
           ballsArray={ballsArray}

--- a/src/components/model/device-views/mixer.tsx
+++ b/src/components/model/device-views/mixer.tsx
@@ -14,7 +14,7 @@ export const Mixer = ({device, handleAddDefs, handleSetSelectedVariable, handleS
   const { variables, id: deviceId } = device;
   return (
     <>
-      <MixerFrame withReplacement={false}/>
+      <MixerFrame/>
       <Balls
         ballsArray={variables}
         deviceId={deviceId}

--- a/src/components/model/device-views/mixer.tsx
+++ b/src/components/model/device-views/mixer.tsx
@@ -1,19 +1,16 @@
 import React from "react";
-import { ClippingDef, IDevice } from "../../../../models/device-model";
-import { MixerFrame } from "../shared/mixer-frame";
-import { Balls } from "../shared/balls";
-import { Speed } from "../../../../types";
+import { ClippingDef, IDevice } from "../../../models/device-model";
+import { MixerFrame } from "./shared/mixer-frame";
+import { Balls } from "./shared/balls";
 
 interface IMixer {
   device: IDevice;
-  isRunning: boolean;
-  speed: Speed;
   handleAddDefs: (def: ClippingDef) => void;
   handleSetSelectedVariable: (variableIdx: number) => void;
   handleSetEditingVarName: (variableIdx: number) => void;
 }
 
-export const Mixer = ({device, isRunning, speed, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName}: IMixer) => {
+export const Mixer = ({device, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName}: IMixer) => {
   const { variables, id: deviceId } = device;
   return (
     <>
@@ -21,8 +18,6 @@ export const Mixer = ({device, isRunning, speed, handleAddDefs, handleSetSelecte
       <Balls
         ballsArray={variables}
         deviceId={deviceId}
-        isRunning={isRunning}
-        speed={speed}
         handleAddDefs={handleAddDefs}
         handleSetSelectedVariable={handleSetSelectedVariable}
         handleSetEditingVarName={handleSetEditingVarName}

--- a/src/components/model/device-views/mixer/mixer.tsx
+++ b/src/components/model/device-views/mixer/mixer.tsx
@@ -2,15 +2,18 @@ import React from "react";
 import { ClippingDef, IDevice } from "../../../../models/device-model";
 import { MixerFrame } from "../shared/mixer-frame";
 import { Balls } from "../shared/balls";
+import { Speed } from "../../../../types";
 
 interface IMixer {
   device: IDevice;
+  isRunning: boolean;
+  speed: Speed;
   handleAddDefs: (def: ClippingDef) => void;
   handleSetSelectedVariable: (variableIdx: number) => void;
   handleSetEditingVarName: (variableIdx: number) => void;
 }
 
-export const Mixer = ({device, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName}: IMixer) => {
+export const Mixer = ({device, isRunning, speed, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName}: IMixer) => {
   const { variables, id: deviceId } = device;
   return (
     <>
@@ -18,6 +21,8 @@ export const Mixer = ({device, handleAddDefs, handleSetSelectedVariable, handleS
       <Balls
         ballsArray={variables}
         deviceId={deviceId}
+        isRunning={isRunning}
+        speed={speed}
         handleAddDefs={handleAddDefs}
         handleSetSelectedVariable={handleSetSelectedVariable}
         handleSetEditingVarName={handleSetEditingVarName}

--- a/src/components/model/device-views/shared/ball.tsx
+++ b/src/components/model/device-views/shared/ball.tsx
@@ -14,10 +14,11 @@ export interface IBall {
   handleSetSelectedVariable: (variableIdx: number) => void;
   handleSetEditingVarName: (variableIdx: number) => void;
   i: number;
+  visibility: "visible" | "hidden";
 }
 
 export const Ball = ({ x, y, transform, radius, text, fontSize,
-  handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName, i, deviceId }: IBall) => {
+  handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName, i, deviceId, visibility }: IBall) => {
   useEffect(() => {
     const id = `${deviceId}-text-clip-${x}-${y}`;
     const clipPath = (
@@ -39,6 +40,7 @@ export const Ball = ({ x, y, transform, radius, text, fontSize,
         stroke="#000"
         strokeWidth={1}
         origin={`${x} ${y}`}
+        visibility={visibility}
       />
       <text
         id={`${deviceId}-ball-label-${text}-${i}`}
@@ -53,6 +55,7 @@ export const Ball = ({ x, y, transform, radius, text, fontSize,
         origin={`${x} ${y}`}
         clipPath={`url(#${deviceId}-text-clip-${x}-${y})`}
         onClick={() => handleSetSelectedVariable(i)}
+        visibility={visibility}
       >
         {text}
       </text>

--- a/src/components/model/device-views/shared/ball.tsx
+++ b/src/components/model/device-views/shared/ball.tsx
@@ -5,6 +5,7 @@ import { ClippingDef } from "../../../../models/device-model";
 export interface IBall {
   x: number;
   y: number;
+  transform: string;
   radius: number;
   text: string;
   fontSize: number;
@@ -15,7 +16,8 @@ export interface IBall {
   i: number;
 }
 
-export const Ball = ({ x, y, radius, text, fontSize, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName, i, deviceId }: IBall) => {
+export const Ball = ({ x, y, transform, radius, text, fontSize,
+  handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName, i, deviceId }: IBall) => {
   useEffect(() => {
     const id = `${deviceId}-text-clip-${x}-${y}`;
     const clipPath = (
@@ -31,6 +33,7 @@ export const Ball = ({ x, y, radius, text, fontSize, handleAddDefs, handleSetSel
       <circle
         cx={x}
         cy={y}
+        transform={transform}
         r={radius}
         fill={getVariableColor(0, 0, false)}
         stroke="#000"
@@ -42,6 +45,7 @@ export const Ball = ({ x, y, radius, text, fontSize, handleAddDefs, handleSetSel
         style={{ cursor: "pointer" }}
         x={x}
         y={y}
+        transform={transform}
         fontSize={fontSize}
         textAnchor="middle"
         dy=".25em"

--- a/src/components/model/device-views/shared/ball.tsx
+++ b/src/components/model/device-views/shared/ball.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { getTextShift, getVariableColor } from "./helpers";
 import { ClippingDef } from "../../../../models/device-model";
+import { useGlobalStateContext } from "../../../../hooks/useGlobalState";
 
 export interface IBall {
   x: number;
@@ -19,6 +20,8 @@ export interface IBall {
 
 export const Ball = ({ x, y, transform, radius, text, fontSize,
   handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName, i, deviceId, visibility }: IBall) => {
+  const { globalState: { isRunning } } = useGlobalStateContext();
+
   useEffect(() => {
     const id = `${deviceId}-text-clip-${x}-${y}`;
     const clipPath = (
@@ -29,8 +32,18 @@ export const Ball = ({ x, y, transform, radius, text, fontSize,
     handleAddDefs({ id, element: clipPath });
   }, [x, y, radius, text, handleAddDefs, deviceId]);
 
+  const handleGroupClick = () => {
+    if (isRunning) return;
+    handleSetEditingVarName(i);
+  };
+
+  const handleTextClick = () => {
+    if (isRunning) return;
+    handleSetSelectedVariable(i);
+  };
+
   return (
-    <g onClick={() => handleSetEditingVarName(i)}>
+    <g onClick={handleGroupClick}>
       <circle
         cx={x}
         cy={y}
@@ -44,7 +57,7 @@ export const Ball = ({ x, y, transform, radius, text, fontSize,
       />
       <text
         id={`${deviceId}-ball-label-${text}-${i}`}
-        style={{ cursor: "pointer" }}
+        style={{ cursor: isRunning ? "default"  : "pointer" }}
         x={x}
         y={y}
         transform={transform}
@@ -54,7 +67,7 @@ export const Ball = ({ x, y, transform, radius, text, fontSize,
         dx={getTextShift(text, (3.8*(radius/fontSize)))}
         origin={`${x} ${y}`}
         clipPath={`url(#${deviceId}-text-clip-${x}-${y})`}
-        onClick={() => handleSetSelectedVariable(i)}
+        onClick={handleTextClick}
         visibility={visibility}
       >
         {text}

--- a/src/components/model/device-views/shared/balls.tsx
+++ b/src/components/model/device-views/shared/balls.tsx
@@ -1,60 +1,84 @@
 import React, { useEffect, useState } from "react";
 import { kBorder, kCapHeight, kMixerContainerHeight, kMixerContainerWidth, kContainerX, kContainerY } from "./constants";
 import { ClippingDef, ICollectorItem } from "../../../../models/device-model";
-import { Ball, IBall } from "./ball";
+import { Ball } from "./ball";
+import { Speed } from "../../../../types";
 
 interface IBalls {
   ballsArray: Array<string>;
   deviceId: string;
+  isRunning: boolean;
+  speed: Speed;
   handleAddDefs: (def: ClippingDef) => void;
   handleSetSelectedVariable: (variableIdx: number) => void;
   handleSetEditingVarName:  (variableIdx: number) => void;
 }
 
-export const Balls = ({ballsArray, deviceId, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName}: IBalls) => {
-  const [ballProps, setBallProps] = useState<Array<IBall>>([]);
+interface IBallPosition {
+  x: number;
+  y: number;
+  targetX?: number|null;
+  targetY?: number|null;
+}
+
+export const Balls = ({ballsArray, deviceId, isRunning, speed, handleAddDefs,
+  handleSetSelectedVariable, handleSetEditingVarName}: IBalls) => {
+  const [ballPositions, setBallPositions] = useState<Array<IBallPosition>>([]);
+  const radius = ballsArray.length < 15 ? 14 : Math.max(14 - (10 * (ballsArray.length - 15)/200), 4);
 
   useEffect(() => {
-    const w = kMixerContainerWidth - kCapHeight - (kBorder * 2);
-    const maxHeight = kMixerContainerHeight * 0.75;
-    const radius = ballsArray.length < 15 ? 14 : Math.max(14 - (10 * (ballsArray.length - 15)/200), 4);
-    const maxInRow = Math.floor(w / (radius * 2));
-    const numRows = Math.ceil(ballsArray.length / maxInRow);
-    const rowHeight = Math.min(radius * 2, maxHeight / numRows);
 
-    const getLabelForVariable = (ball: string | ICollectorItem) => {
-      if (typeof ball === "object"){
-        const firstKey = Object.keys(ball)[0];
-        return ball[firstKey];
-      } else {
-        return ball;
-      }
-    };
+      const w = kMixerContainerWidth - kCapHeight - (kBorder * 2);
+      const maxHeight = kMixerContainerHeight * 0.75;
+      const maxInRow = Math.floor(w / (radius * 2));
+      const numRows = Math.ceil(ballsArray.length / maxInRow);
+      const rowHeight = Math.min(radius * 2, maxHeight / numRows);
+      setBallPositions(ballsArray.map((ball, i) => {
+        const rowNumber = Math.floor(i / maxInRow);
+        const rowIndex = i % maxInRow;
+        const x = (rowNumber % 2 === 0) ? kContainerX + kBorder + radius + (rowIndex * radius * 2) : kContainerX + kMixerContainerWidth - kBorder - kCapHeight - radius - (rowIndex * radius * 2);
+        const y = kContainerY + kMixerContainerHeight - kBorder - radius - (rowHeight * rowNumber);
+        return {x, y};
+      }));
+  }, [ballsArray, radius]);
 
-    const maxVariableLength = ballsArray.reduce(function(max, ball) {
-      const length = getLabelForVariable(ball).toString().length;
-      return Math.max(max, length);
-    }, 0);
-
-    const fontScaling = 1 - Math.min(Math.max((maxVariableLength - 5) * 0.1, 0), 0.4);
-    const fontSize = radius * fontScaling;
-
-    const props = [];
-
-    for (let i = 0; i < ballsArray.length; i++) {
-      const rowNumber = Math.floor(i / maxInRow);
-      const rowIndex = i % maxInRow;
-      const x = (rowNumber % 2 === 0) ? kContainerX + kBorder + radius + (rowIndex * radius * 2) : kContainerX + kMixerContainerWidth - kBorder - kCapHeight - radius - (rowIndex * radius * 2);
-      const y = kContainerY + kMixerContainerHeight - kBorder - radius - (rowHeight * rowNumber);
-      const text = ballsArray[i];
-      props.push({x, y, radius, text, fontSize, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName, i, deviceId});
+  const getLabelForVariable = (ball: string | ICollectorItem) => {
+    if (typeof ball === "object"){
+      const firstKey = Object.keys(ball)[0];
+      return ball[firstKey];
+    } else {
+      return ball;
     }
-    setBallProps(props);
-  }, [ballsArray, deviceId, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName]);
+  };
+  const maxVariableLength = ballsArray.reduce(function(max, ball) {
+    const length = getLabelForVariable(ball).toString().length;
+    return Math.max(max, length);
+  }, 0);
+
+  const fontScaling = 1 - Math.min(Math.max((maxVariableLength - 5) * 0.1, 0), 0.4);
+  const fontSize = radius * fontScaling;
 
   return (
     <>
-      {ballProps.map((props, i) => <Ball key={i} {...props} />)}
+      { ballPositions.map((position, i) => {
+        const {x, y} = position;
+        const text = getLabelForVariable(ballsArray[i]);
+        return (
+          <Ball
+            key={`${deviceId}-ball-${text}-${i}`}
+            x={x}
+            y={y}
+            i={i}
+            radius={radius}
+            deviceId={deviceId}
+            text={`${text}`}
+            fontSize={fontSize}
+            handleAddDefs={handleAddDefs}
+            handleSetEditingVarName={handleSetEditingVarName}
+            handleSetSelectedVariable={handleSetSelectedVariable}
+          />
+        );
+      })}
     </>
   );
 };

--- a/src/components/model/device-views/shared/balls.tsx
+++ b/src/components/model/device-views/shared/balls.tsx
@@ -28,7 +28,6 @@ export const Balls = ({ballsArray, deviceId, handleAddDefs, handleSetSelectedVar
   const [ballPositions, setBallPositions] = useState<Array<IBallPosition>>([]);
   const radius = ballsArray.length < 15 ? 14 : Math.max(14 - (10 * (ballsArray.length - 15)/200), 4);
 
-
   useEffect(() => {
     if (deviceAnimationStep?.id !== deviceId) {
       const w = kMixerContainerWidth - kCapHeight - (kBorder * 2);
@@ -89,24 +88,25 @@ export const Balls = ({ballsArray, deviceId, handleAddDefs, handleSetSelectedVar
           return prevState.map((position, index) => {
             if (index !== selectedVariableIdx) {
               // calculate velocity and next position
-              let { vx, vy, x, y } = position;
+              const { vx, vy, x, y } = position;
               const dx = vx * animationSpeedBoost;
               const dy = vy * animationSpeedBoost;
               let newX = x + dx;
               let newY = y + dy;
-
+              let newVx = vx;
+              let newVy = vy;
               // check for wall collisions and adjust velocity
               if (newX - radius < kContainerX + kBorder || newX + radius > kContainerX + kMixerContainerWidth - kCapHeight - kBorder) {
-                vx = -vx;
+                newVx = -vx;
                 newX = x; // reset the position since collision occurred
               }
               if (newY - radius < kContainerY + kBorder || newY + radius > kContainerY + kMixerContainerHeight - kBorder) {
-                vy = -vy;
+                newVy = -vy;
                 newY = y; // reset the position since collision occurred
               }
 
               const transform = `translate(${dx},${dy})`;
-              return { ...position, x: newX, y: newY, vx, vy, transform};
+              return { ...position, x: newX, y: newY, vx: newVx, vy: newVy, transform};
             } else {
               return position;
             }

--- a/src/components/model/device-views/shared/mixer-frame.tsx
+++ b/src/components/model/device-views/shared/mixer-frame.tsx
@@ -2,19 +2,15 @@ import React from "react";
 import { kBorder, kCapHeight, kCapWidth, kMixerContainerHeight, kMixerContainerWidth, kContainerX, kContainerY } from "./constants";
 import "./mixer-frame.scss";
 
-interface IMixerFrame {
-  withReplacement: boolean;
-}
-
-export const MixerFrame = ({withReplacement}: IMixerFrame) => {
-  const halfb = (kBorder/2);
+export const MixerFrame = () => {
+  const halfb = kBorder / 2;
   const mx = kContainerX + halfb;
   const my = kContainerY + halfb;
-  const h = kMixerContainerHeight - kBorder;
-  const shoulder = (h - kCapWidth) / 2;
+  const w = kMixerContainerWidth - kBorder;
+  const shoulder = (w - kCapWidth) / 2;
   const cap = kCapHeight - halfb;
-  const w = kMixerContainerWidth - kCapHeight - halfb;
-  const pathStr = `m${mx},${my} h ${w} v ${shoulder} h ${cap} v ${kCapWidth} h -${cap} v ${shoulder} h -${w} z`;
+  const h = kMixerContainerHeight - halfb;
+  const pathStr = `m${mx},${my + h} v -${h} h ${shoulder} v -${cap} h ${kCapWidth} v ${cap} h ${shoulder} v ${h} z`;
   const clipping = "none";
 
   return (

--- a/src/components/model/device-views/spinner/spinner.tsx
+++ b/src/components/model/device-views/spinner/spinner.tsx
@@ -4,6 +4,7 @@ import { kSpinnerRadius, kSpinnerX, kSpinnerY } from "../shared/constants";
 import { getTextShift, getVariableColor } from "../shared/helpers";
 import { Wedge } from "./wedge";
 import { SeparatorLine } from "./separator-lines";
+import { useGlobalStateContext } from "../../../../hooks/useGlobalState";
 
 interface ISpinner {
   device: IDevice;
@@ -19,6 +20,7 @@ interface ISpinner {
 
 export const Spinner = ({device, selectedVariableIdx, isDragging, handleSetSelectedVariable, handleDeleteWedge,
   handleSetEditingPct, handleSetEditingVarName, handleAddDefs, handleStartDrag}: ISpinner) => {
+  const { globalState: { isRunning } } = useGlobalStateContext();
   const [fontSize, setFontSize] = useState(16);
   const [selectedWedge, setSelectedWedge] = useState<string|null>(null);
   const [numUniqueVariables, setNumUniqueVariables] = useState(0);
@@ -53,6 +55,11 @@ export const Spinner = ({device, selectedVariableIdx, isDragging, handleSetSelec
     return { lastPercent, currPercent };
   }
 
+  const handleCircleClick = () => {
+    if (isRunning) return;
+    handleSetSelectedVariable(0);
+  };
+
   return (
     [...new Set(variables)].length === 1 ?
       <>
@@ -73,7 +80,7 @@ export const Spinner = ({device, selectedVariableIdx, isDragging, handleSetSelec
           dx={getTextShift(variables[0], variables[0].length)}
           fill="#000"
           fontSize={fontSize}
-          onClick={() => handleSetSelectedVariable(0)}
+          onClick={handleCircleClick}
           style={{ cursor: "pointer" }}
         >
           {variables[0]}

--- a/src/components/model/device-views/spinner/wedge.tsx
+++ b/src/components/model/device-views/spinner/wedge.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { kSpinnerRadius, kSpinnerX, kSpinnerY } from "../shared/constants";
 import { getCoordinatesForPercent, getTextShift, getVariableColor } from "../shared/helpers";
 import { ClippingDef } from "../../../../models/device-model";
+import { useGlobalStateContext } from "../../../../hooks/useGlobalState";
 
 interface IWedge {
   percent: number;
@@ -48,6 +49,7 @@ const getEllipseCoords = (percent: number) => {
 export const Wedge = ({percent, lastPercent, index, variableName, labelFontSize, numUniqueVariables,
   varArrayIdx, selectedWedge, isLastVariable, isDragging, deviceId, handleSetSelectedVariable, handleDeleteWedge,
   handleSetEditingPct, handleSetEditingVarName, handleAddDefs, handleStartDrag}: IWedge) => {
+  const { globalState: { isRunning } } = useGlobalStateContext();
   const [wedgePath, setWedgePath] = useState("");
   const [wedgeColor, setWedgeColor] = useState(selectedWedge === variableName ? kDarkTeal : "");
   const [labelPos, setLabelPos] = useState<{x: number, y: number}>({x: 0, y: 0});
@@ -103,15 +105,18 @@ export const Wedge = ({percent, lastPercent, index, variableName, labelFontSize,
   }, [percent, lastPercent, index, variableName, selectedWedge, handleAddDefs, deviceId, varArrayIdx, numUniqueVariables]);
 
   const handleLabelClick = (e: React.MouseEvent) => {
+    if (isRunning) return;
     handleSetEditingVarName(varArrayIdx);
     handleSetSelectedVariable(varArrayIdx);
   };
 
   const handleWedgeClick = (e: React.MouseEvent) => {
+    if (isRunning) return;
     handleSetSelectedVariable(varArrayIdx);
   };
 
   const handleMouseDown = (e: React.MouseEvent) => {
+    if (isRunning) return;
     handleSetSelectedVariable(varArrayIdx);
     handleStartDrag({x: point1.x, y: point1.y});
   };
@@ -134,14 +139,14 @@ export const Wedge = ({percent, lastPercent, index, variableName, labelFontSize,
         fill={wedgeColor}
         className="wedge"
         onClick={handleWedgeClick}
-        style={{ cursor: isDragging? "grabbing" : "pointer" }}
+        style={{ cursor: isRunning ? "default" : isDragging? "grabbing" : "pointer" }}
       >
         <title>{Math.round(percent * 100)}%</title>
       </path>
       {/* variable name label */}
       <text
         id={`${deviceId}-wedge-label-${variableName}-${varArrayIdx}`}
-        style={{ cursor: isDragging? "grabbing" : "pointer" }}
+        style={{ cursor: isRunning ? "default" : isDragging? "grabbing" : "pointer" }}
         x={labelPos.x}
         y={labelPos.y}
         textAnchor="middle"
@@ -162,7 +167,7 @@ export const Wedge = ({percent, lastPercent, index, variableName, labelFontSize,
           d={edgePath}
           stroke={wedgeColor}
           strokeWidth={10}
-          style={{cursor: isDragging ? "grabbing" : "grab"}}
+          style={{cursor: isRunning ? "default" : isDragging ? "grabbing" : "grab"}}
           onMouseDown={handleMouseDown}
           clipPath={`url(#${deviceId}-wedge-clip-${variableName}`}
         />

--- a/src/components/model/device.tsx
+++ b/src/components/model/device.tsx
@@ -16,7 +16,6 @@ import { SetVariableSeriesModal } from "./variable-setting-modal";
 import DeleteIcon from "../../assets/delete-icon.svg";
 import VisibleIcon from "../../assets/visibility-on-icon.svg";
 import { parseSpecifier } from "../../utils/utils";
-import { useAnimationContext } from "../../hooks/useAnimation";
 
 import "./device.scss";
 
@@ -42,17 +41,6 @@ export const Device = (props: IProps) => {
   const { viewType, variables } = device;
   const svgRef = useRef<SVGSVGElement>(null);
   const multipleColumns = model.columns.length > 1;
-  const [backgroundColor, setBackgroundColor] = useState<string>("");
-  const { deviceAnimationStep } = useAnimationContext();
-
-  useEffect(() => {
-    if (device.id === deviceAnimationStep?.id) {
-      setBackgroundColor("red");
-    } else {
-      setBackgroundColor("");
-    }
-
-  }, [deviceAnimationStep, device.id]);
 
   useEffect(() => {
     const fetchDataContexts = async () => {
@@ -294,7 +282,7 @@ export const Device = (props: IProps) => {
           {isSelectedDevice && <VisibleIcon />}
         </div>
         <div className="device-svg-container">
-          <div className={`device-frame ${viewType}`} style={{backgroundColor}}>
+          <div className={`device-frame ${viewType}`}>
             <svg
               className="svg"
               ref={svgRef}

--- a/src/components/model/device.tsx
+++ b/src/components/model/device.tsx
@@ -300,6 +300,8 @@ export const Device = (props: IProps) => {
                 viewType === ViewType.Mixer ?
                   <Mixer
                     device={device}
+                    isRunning={globalState.isRunning}
+                    speed={globalState.speed}
                     handleAddDefs={handleAddDefs}
                     handleSetSelectedVariable={handleSetSelectedVariable}
                     handleSetEditingVarName={() => setIsEditingVarName(true)}
@@ -318,6 +320,8 @@ export const Device = (props: IProps) => {
                   /> :
                   <Collector
                     device={device}
+                    isRunning={globalState.isRunning}
+                    speed={globalState.speed}
                     handleAddDefs={handleAddDefs}
                     handleSetSelectedVariable={handleSetSelectedVariable}
                     handleSetEditingVarName={() => setIsEditingVarName(true)}

--- a/src/components/model/device.tsx
+++ b/src/components/model/device.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useGlobalStateContext } from "../../hooks/useGlobalState";
 import { ClippingDef, IDataContext, IDevice, IItem, IItems, IVariables, ViewType } from "../../models/device-model";
-import { Mixer } from "./device-views/mixer/mixer";
+import { Mixer } from "./device-views/mixer";
 import { Spinner } from "./device-views/spinner/spinner";
 import { Collector } from "./device-views/collector";
 import { NameLabelInput } from "./name-label-input";
@@ -312,8 +312,6 @@ export const Device = (props: IProps) => {
                 viewType === ViewType.Mixer ?
                   <Mixer
                     device={device}
-                    isRunning={globalState.isRunning}
-                    speed={globalState.speed}
                     handleAddDefs={handleAddDefs}
                     handleSetSelectedVariable={handleSetSelectedVariable}
                     handleSetEditingVarName={() => setIsEditingVarName(true)}
@@ -332,8 +330,6 @@ export const Device = (props: IProps) => {
                   /> :
                   <Collector
                     device={device}
-                    isRunning={globalState.isRunning}
-                    speed={globalState.speed}
                     handleAddDefs={handleAddDefs}
                     handleSetSelectedVariable={handleSetSelectedVariable}
                     handleSetEditingVarName={() => setIsEditingVarName(true)}

--- a/src/components/model/device.tsx
+++ b/src/components/model/device.tsx
@@ -16,6 +16,7 @@ import { SetVariableSeriesModal } from "./variable-setting-modal";
 import DeleteIcon from "../../assets/delete-icon.svg";
 import VisibleIcon from "../../assets/visibility-on-icon.svg";
 import { parseSpecifier } from "../../utils/utils";
+import { useAnimationContext } from "../../hooks/useAnimation";
 
 import "./device.scss";
 
@@ -41,6 +42,17 @@ export const Device = (props: IProps) => {
   const { viewType, variables } = device;
   const svgRef = useRef<SVGSVGElement>(null);
   const multipleColumns = model.columns.length > 1;
+  const [backgroundColor, setBackgroundColor] = useState<string>("");
+  const { deviceAnimationStep } = useAnimationContext();
+
+  useEffect(() => {
+    if (device.id === deviceAnimationStep?.id) {
+      setBackgroundColor("red");
+    } else {
+      setBackgroundColor("");
+    }
+
+  }, [deviceAnimationStep, device.id]);
 
   useEffect(() => {
     const fetchDataContexts = async () => {
@@ -282,7 +294,7 @@ export const Device = (props: IProps) => {
           {isSelectedDevice && <VisibleIcon />}
         </div>
         <div className="device-svg-container">
-          <div className={`device-frame ${viewType}`}>
+          <div className={`device-frame ${viewType}`} style={{backgroundColor}}>
             <svg
               className="svg"
               ref={svgRef}

--- a/src/components/model/formula-editor.tsx
+++ b/src/components/model/formula-editor.tsx
@@ -14,7 +14,7 @@ interface IProps {
 const kMaxLabelHeight = 22;
 
 export const FormulaEditor = ({source, target, columnIndex, arrowMidPoint, svgWidth, horizontalArrow}: IProps) => {
-  const {setGlobalState} = useGlobalStateContext();
+  const {globalState: { isRunning }, setGlobalState} = useGlobalStateContext();
   const [editing, setEditing] = useState(false);
   const [label, setLabel] = useState(source.formulas[target.id]);
   const labelRef = useRef<HTMLDivElement>(null);
@@ -28,7 +28,7 @@ export const FormulaEditor = ({source, target, columnIndex, arrowMidPoint, svgWi
   }, [label]);
 
   const handleToggleEditing = () => {
-    setEditing(prev => {
+    setEditing((prev) => {
       setTimeout(() => {
         inputRef.current?.focus();
         inputRef.current?.select();
@@ -100,10 +100,17 @@ export const FormulaEditor = ({source, target, columnIndex, arrowMidPoint, svgWi
     <div ref={labelRef} className="arrow-label" style={labelStyle}>
       { editing
         ? <form className="label-form" onSubmit={handleSubmitEdit}>
-            <input type="text" ref={inputRef} defaultValue={label} onKeyDown={handleLabelKeyDown}
+            <input disabled={isRunning} type="text" ref={inputRef} defaultValue={label} onKeyDown={handleLabelKeyDown}
                 style={{height: kMaxLabelHeight}} />
           </form>
-        : <div className={`label-span ${source.id}`} tabIndex={0} onKeyDown={handleToggleEditing} onClick={handleToggleEditing}>{label}</div>
+        : <div
+            className={`label-span ${source.id} ${isRunning ? "disabled" : ""}`}
+            tabIndex={0}
+            onKeyDown={handleToggleEditing}
+            onClick={isRunning ? undefined : handleToggleEditing}
+          >
+            {label}
+          </div>
       }
     </div>
   );

--- a/src/components/model/model-component.tsx
+++ b/src/components/model/model-component.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useGlobalStateContext } from "../../hooks/useGlobalState";
+import { AnimationContext, useAnimationContextValue } from "../../hooks/useAnimation";
 import { useResizer } from "../../hooks/use-resizer";
 import { Column } from "./column";
 import { ModelHeader } from "./model-header";
@@ -30,32 +31,36 @@ export const ModelTab = () => {
   };
 
   const modelHeaderStyle = {width: (model.columns.length * kMinColumnWidth) + kSelectedSamplesDivWidth};
+  const animationContext = useAnimationContextValue();
 
   return (
-    <div className="model-tab">
-      <ModelHeader
-        modelHeaderStyle={modelHeaderStyle}
-        showHelp={showHelp}
-        setShowHelp={setShowHelp}
-        isWide={isWide}
-        handleOpenHelp={handleOpenHelp}
-      />
-      <div className="model-container">
-        <div className={`device-outputs-container`}>
-            {model.columns.map((column, columnIndex) => {
-              return (
-                <Column
-                  key={`column-${columnIndex}`}
-                  column={column}
-                  columnIndex={columnIndex}
-                />
-              );
-            })}
-          <div className="outputs">
-            <div className="outputs-title">{`sample 1`}</div>
+    <AnimationContext.Provider value={animationContext}>
+      <div className="model-tab">
+        <ModelHeader
+          modelHeaderStyle={modelHeaderStyle}
+          showHelp={showHelp}
+          setShowHelp={setShowHelp}
+          isWide={isWide}
+          handleOpenHelp={handleOpenHelp}
+        />
+          <div className="model-container">
+            <div className={`device-outputs-container`}>
+                {model.columns.map((column, columnIndex) => {
+                  return (
+                    <Column
+                      key={`column-${columnIndex}`}
+                      column={column}
+                      columnIndex={columnIndex}
+                    />
+                  );
+                })}
+              <div className="outputs">
+                <div className="outputs-title">{`sample 1`}</div>
+              </div>
+            </div>
           </div>
-        </div>
       </div>
-    </div>
+    </AnimationContext.Provider>
+
   );
 };

--- a/src/components/model/model-header.tsx
+++ b/src/components/model/model-header.tsx
@@ -16,7 +16,7 @@ interface IModelHeader {
 export const ModelHeader = (props: IModelHeader) => {
   const { modelHeaderStyle, showHelp, setShowHelp, isWide, handleOpenHelp } = props;
   const { globalState, setGlobalState } = useGlobalStateContext();
-  const { repeat, sampleSize, numSamples, enableRunButton } = globalState;
+  const { repeat, sampleSize, numSamples, enableRunButton, isRunning } = globalState;
   const { handleStartRun, deleteAll } = useCodapAPI();
 
   const handleClearData = () => {
@@ -74,23 +74,23 @@ export const ModelHeader = (props: IModelHeader) => {
   return (
     <div className="model-header" style={modelHeaderStyle}>
       <div className="model-controls">
-        <button className={`start-button ${!enableRunButton ? "disabled" : ""}`} onClick={handleStartRun}>START</button>
-        <button className={`stop-button ${enableRunButton ? "disabled" : ""}`}>STOP</button>
+        <button disabled={isRunning} className={`start-button ${!enableRunButton ? "disabled" : ""}`} onClick={handleStartRun}>START</button>
+        <button disabled={!isRunning} className={`stop-button ${enableRunButton ? "disabled" : ""}`}>STOP</button>
         <SpeedSlider />
-        <button className="clear-data-button" onClick={handleClearData}>CLEAR DATA</button>
+        <button disabled={isRunning} className={`clear-data-button ${isRunning ? "disabled" : ""}`} onClick={handleClearData}>CLEAR DATA</button>
       </div>
       <div className="select-repeat-controls">
         <div className="select-repeat-selection">
           <div className="select-repeat-dropdown">
-            <select onChange={handleSelectRepeat}>
+            <select disabled={isRunning} onChange={handleSelectRepeat}>
               <option className={`select-repeat-option`} value="select">Select</option>
               <option className={`select-repeat-option`} value="repeat">Repeat</option>
             </select>
           </div>
-          <input type="text" id="sample_size" value={sampleSize} onChange={handleSampleSizeChange}></input>
+          <input disabled={isRunning} type="text" id="sample_size" value={sampleSize} onChange={handleSampleSizeChange}></input>
           <span>{`${repeat ? "selecting" : ""} items`}</span>
           <div className="select-replacement-dropdown">
-            <select onChange={handleSelectReplacement}>
+            <select disabled={isRunning} onChange={handleSelectReplacement}>
               <option value="with">with replacement</option>
               <option value="without">without replacement</option>
             </select>
@@ -107,7 +107,7 @@ export const ModelHeader = (props: IModelHeader) => {
       </div>
       <div className="collect-controls">
         <span>Collect</span>
-        <input type="text" id="num_samples" value={numSamples} onChange={handleNumSamplesChange}></input>
+        <input disabled={isRunning} type="text" id="num_samples" value={numSamples} onChange={handleNumSamplesChange}></input>
         <span>samples</span>
       </div>
     </div>

--- a/src/components/model/model-speed-slider.tsx
+++ b/src/components/model/model-speed-slider.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { useGlobalStateContextValue } from "../../hooks/useGlobalState";
+import { useGlobalStateContext } from "../../hooks/useGlobalState";
 import { Speed, speedLabels } from "../../types";
 
 export const SpeedSlider = () => {
-  const { globalState, setGlobalState } = useGlobalStateContextValue();
+  const { globalState, setGlobalState } = useGlobalStateContext();
   const { speed } = globalState;
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/model/model-speed-slider.tsx
+++ b/src/components/model/model-speed-slider.tsx
@@ -1,36 +1,40 @@
-import React, {useState} from "react";
+import React from "react";
+import { useGlobalStateContextValue } from "../../hooks/useGlobalState";
+import { Speed, speedLabels } from "../../types";
 
 export const SpeedSlider = () => {
-  const [value, setValue] = useState(1);
-  const speedValue = ["Slow", "Medium", "Fast", "Fastest"];
+  const { globalState, setGlobalState } = useGlobalStateContextValue();
+  const { speed } = globalState;
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(parseInt(event.target.value, 10)); // Parse the value as an integer
+    setGlobalState(draft => {
+      draft.speed = parseInt(event.target.value, 10);
+    });
   };
 
   return (
     <div className="speed-slider">
       <input
         type="range"
-        min={0}
-        max={3}
-        value={value}
+        min={Speed.Slow}
+        max={Speed.Fastest}
+        value={speed}
         onChange={handleChange}
         step={1}
         list="speedSettings"
         className="slider"
       />
       <div className="tick-marks-container">
-          {speedValue.map((speed, i) => {
+          {Object.keys(speedLabels).map((label, i) => {
             return (
-              <div className="tick-mark" key={`tick-${i}`}>
+              <div className="tick-mark" key={`tick-${label}-${i}`}>
                 <div className="tick-line"/>
               </div>
             );
           })}
       </div>
       <span id="speed-text" data-text="DG.plugin.Sampler.top-bar.medium-speed">
-        {speedValue[value]}
+        {speedLabels[speed]}
       </span>
     </div>
   );

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -5,13 +5,12 @@ import { kDataContextName } from "../contants";
 import { useGlobalStateContext } from "./useGlobalState";
 
 export const createAnimationSteps = (animationResults: IExperimentResultsForAnimation, results: IExperimentResults, speed: Speed, onComplete: () => void): Array<AnimationStep> => {
-  const timeout = speed === Speed.Fastest ? 0 : 1200 / (speed + 1);
   const steps = animationResults.reduce<Array<AnimationStep>>((acc, sample) => {
     return sample.reduce<Array<AnimationStep>>((acc2, run, runIndex) => {
       return Object.keys(run.results).reduce((acc3, id, deviceIdx) => {
         const isLastStepInSampleRun = runIndex === sample.length - 1 && deviceIdx === Object.keys(run.results).length - 1;
         const selectedVariable = run.results[id];
-        const deviceAnimationStep: AnimationStep = {duration: timeout, kind: "device", selectedVariable, id};
+        const deviceAnimationStep: AnimationStep = {kind: "device", selectedVariable, id};
 
         if (isLastStepInSampleRun) {
           const onSampleComplete = async () => {
@@ -26,7 +25,7 @@ export const createAnimationSteps = (animationResults: IExperimentResultsForAnim
       }, acc2);
     }, acc);
   }, []);
-  steps.push({duration: 1000, kind: "final", onComplete});
+  steps.push({kind: "final", onComplete});
   return steps;
 };
 
@@ -63,10 +62,9 @@ export const useAnimationContextValue = () : IAnimationContext => {
     if (animationSteps.length === 0) {
       return;
     }
-
-    // to-do: animate current step
+    const timeout = speed === Speed.Fastest ? 0 : 1200 / (speed + 1);
     clearTimeout(animationTimeoutRef.current);
-    animationTimeoutRef.current = setTimeout(animationTimeout, animationSteps[0].duration);
+    animationTimeoutRef.current = setTimeout(animationTimeout, timeout);
   }, [animationSteps, animationTimeout, speed]);
 
   if (animationSteps.length === 0) {

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -1,9 +1,10 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
-import { AnimationStep, ArrowAnimationStep, DeviceAnimationStep, FinalAnimationStep, IExperimentResults, IExperimentResultsForAnimation } from "../types";
+import { AnimationStep, ArrowAnimationStep, DeviceAnimationStep, FinalAnimationStep, IExperimentResults, IExperimentResultsForAnimation, Speed } from "../types";
 import { createItems } from "@concord-consortium/codap-plugin-api";
 import { kDataContextName } from "../contants";
 
-export const createAnimationSteps = (animationResults: IExperimentResultsForAnimation, results: IExperimentResults, onComplete: () => void): Array<AnimationStep> => {
+export const createAnimationSteps = (animationResults: IExperimentResultsForAnimation, results: IExperimentResults, speed: Speed, onComplete: () => void): Array<AnimationStep> => {
+  const timeout = speed === Speed.Fastest ? 0 : 600 / speed + 1;
   const steps = animationResults.reduce<Array<AnimationStep>>((acc, sample) => {
     return sample.reduce<Array<AnimationStep>>((acc2, run, runIndex) => {
       return Object.keys(run.results).reduce((acc3, id, deviceIdx) => {
@@ -13,9 +14,9 @@ export const createAnimationSteps = (animationResults: IExperimentResultsForAnim
             const sampleResults = results.filter((result) => result.sample === run.sampleNumber);
             await createItems(kDataContextName, sampleResults);
           };
-          acc3.push({duration: 500, kind: "device", id, onComplete: onSampleComplete});
+          acc3.push({duration: timeout, kind: "device", id, onComplete: onSampleComplete});
         } else {
-          acc3.push({duration: 500, kind: "device", id});
+          acc3.push({duration: timeout, kind: "device", id});
         }
         return acc3;
       }, acc2);

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -1,0 +1,87 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+import { AnimationStep, ArrowAnimationStep, DeviceAnimationStep, FinalAnimationStep, IExperimentResults, IExperimentResultsForAnimation } from "../types";
+import { createItems } from "@concord-consortium/codap-plugin-api";
+import { kDataContextName } from "../contants";
+
+export const createAnimationSteps = (animationResults: IExperimentResultsForAnimation, results: IExperimentResults, onComplete: () => void): Array<AnimationStep> => {
+  const steps = animationResults.reduce<Array<AnimationStep>>((acc, sample) => {
+    return sample.reduce<Array<AnimationStep>>((acc2, run, runIndex) => {
+      return Object.keys(run.results).reduce((acc3, id, deviceIdx) => {
+        const isLastStepInSampleRun = runIndex === sample.length - 1 && deviceIdx === Object.keys(run.results).length - 1;
+        if (isLastStepInSampleRun) {
+          const onSampleComplete = async () => {
+            const sampleResults = results.filter((result) => result.sample === run.sampleNumber);
+            await createItems(kDataContextName, sampleResults);
+          };
+          acc3.push({duration: 500, kind: "device", id, onComplete: onSampleComplete});
+        } else {
+          acc3.push({duration: 500, kind: "device", id});
+        }
+        return acc3;
+      }, acc2);
+    }, acc);
+  }, []);
+  steps.push({duration: 1000, kind: "final", onComplete});
+  return steps;
+};
+
+export interface IAnimationContext {
+  deviceAnimationStep?: DeviceAnimationStep,
+  arrowAnimationStep?: ArrowAnimationStep,
+  finalAnimationStep?: FinalAnimationStep,
+  setAnimationSteps: React.Dispatch<React.SetStateAction<AnimationStep[]>>
+}
+
+
+export const useAnimationContextValue = () : IAnimationContext => {
+  const [animationSteps, setAnimationSteps] = useState<AnimationStep[]>([]);
+  const animationTimeoutRef = useRef<number>();
+
+  const animationTimeout = useCallback(async () => {
+    if (animationSteps.length === 0) {
+      return;
+    }
+    const {onComplete} = animationSteps[0];
+    if (onComplete) {
+      await onComplete();
+    }
+
+    const newAnimationSteps = [...animationSteps];
+    newAnimationSteps.shift();
+
+    setAnimationSteps(newAnimationSteps);
+  }, [animationSteps]);
+
+
+  useEffect(() => {
+    if (animationSteps.length === 0) {
+      return;
+    }
+
+    // to-do: animate current step
+    clearTimeout(animationTimeoutRef.current);
+    animationTimeoutRef.current = setTimeout(animationTimeout, animationSteps[0].duration);
+  }, [animationSteps, animationTimeout]);
+
+  if (animationSteps.length === 0) {
+    return {
+      deviceAnimationStep: undefined,
+      arrowAnimationStep: undefined,
+      finalAnimationStep: undefined,
+      setAnimationSteps
+    };
+  }
+
+  const currentAnimationStep = animationSteps[0];
+
+  return {
+    deviceAnimationStep: currentAnimationStep.kind === "device" ? currentAnimationStep : undefined,
+    arrowAnimationStep: currentAnimationStep.kind === "arrow" ? currentAnimationStep : undefined,
+    finalAnimationStep: currentAnimationStep.kind === "final" ? currentAnimationStep : undefined,
+    setAnimationSteps
+  };
+};
+
+export const AnimationContext = createContext<IAnimationContext>({setAnimationSteps: () => undefined});
+export const useAnimationContext = () => useContext(AnimationContext);
+

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -2,9 +2,10 @@ import { createContext, useCallback, useContext, useEffect, useRef, useState } f
 import { AnimationStep, ArrowAnimationStep, DeviceAnimationStep, FinalAnimationStep, IExperimentResults, IExperimentResultsForAnimation, Speed } from "../types";
 import { createItems } from "@concord-consortium/codap-plugin-api";
 import { kDataContextName } from "../contants";
+import { useGlobalStateContext } from "./useGlobalState";
 
 export const createAnimationSteps = (animationResults: IExperimentResultsForAnimation, results: IExperimentResults, speed: Speed, onComplete: () => void): Array<AnimationStep> => {
-  const timeout = speed === Speed.Fastest ? 0 : 600 / (speed + 1);
+  const timeout = speed === Speed.Fastest ? 0 : 1200 / (speed + 1);
   const steps = animationResults.reduce<Array<AnimationStep>>((acc, sample) => {
     return sample.reduce<Array<AnimationStep>>((acc2, run, runIndex) => {
       return Object.keys(run.results).reduce((acc3, id, deviceIdx) => {
@@ -38,6 +39,7 @@ export interface IAnimationContext {
 
 
 export const useAnimationContextValue = () : IAnimationContext => {
+  const {globalState: {speed}} = useGlobalStateContext();
   const [animationSteps, setAnimationSteps] = useState<AnimationStep[]>([]);
   const animationTimeoutRef = useRef<number>();
 
@@ -65,7 +67,7 @@ export const useAnimationContextValue = () : IAnimationContext => {
     // to-do: animate current step
     clearTimeout(animationTimeoutRef.current);
     animationTimeoutRef.current = setTimeout(animationTimeout, animationSteps[0].duration);
-  }, [animationSteps, animationTimeout]);
+  }, [animationSteps, animationTimeout, speed]);
 
   if (animationSteps.length === 0) {
     return {

--- a/src/hooks/useCodapAPI.tsx
+++ b/src/hooks/useCodapAPI.tsx
@@ -226,6 +226,10 @@ export const useCodapAPI = () => {
 
   const handleStartRun = async () => {
     const attrNames = model.columns.map(column => column.name);
+    setGlobalState(draft => {
+      draft.isRunning = true;
+      draft.enableRunButton = false;
+    });
     await findOrCreateDataContext(attrNames);
 
     const experimentNum = model.experimentNum

--- a/src/hooks/useCodapAPI.tsx
+++ b/src/hooks/useCodapAPI.tsx
@@ -217,10 +217,14 @@ export const useCodapAPI = () => {
   };
 
   const handleStartRun = async () => {
-    // proof of concept that we can "run" the model and add items to CODAP
     setGlobalState(draft => {
-      draft.modelIsRunning = true;
+      draft.isRunning = true;
     });
+
+    run();
+  };
+
+  const run = async () => {
     const experimentNum = model.experimentNum
     ? createNewExperiment
         ? model.experimentNum + 1
@@ -237,6 +241,7 @@ export const useCodapAPI = () => {
         draft.enableRunButton = true;
         draft.createNewExperiment = false;
         draft.model.mostRecentRunNumber = model.mostRecentRunNumber + Number(numSamples);
+        draft.isRunning = false;
       });
     }
   };

--- a/src/hooks/useCodapAPI.tsx
+++ b/src/hooks/useCodapAPI.tsx
@@ -5,16 +5,16 @@ import {
   codapInterface,
   createChildCollection,
   createDataContext,
-  createItems,
   createNewAttribute,
   createParentCollection,
   createTable,
   getAttributeList,
   getDataContext
 } from "@concord-consortium/codap-plugin-api";
-import { AttrMap, IAttribute } from "../types";
+import { AttrMap, IAttribute, IExperimentResults, IExperimentResultsForAnimation, ISampleResults } from "../types";
 import { extractVariablesFromFormula, formatFormula } from "../utils/utils";
 import { getDeviceById } from "../models/model-model";
+import { createAnimationSteps, useAnimationContext } from "./useAnimation";
 
 export const kDataContextName = "Sampler";
 type TCODAPRequest = { action: string; resource: string; };
@@ -22,6 +22,7 @@ type TCODAPRequest = { action: string; resource: string; };
 export const useCodapAPI = () => {
   const { globalState, setGlobalState } = useGlobalStateContext();
   const { model, sampleSize, numSamples, replacement, createNewExperiment, attrMap } = globalState;
+  const { setAnimationSteps } = useAnimationContext();
 
   const evaluateResult = async (formula: string, value: Record<string, string>) => {
     const tMsg = {
@@ -44,13 +45,14 @@ export const useCodapAPI = () => {
 
   const runExperiment = async () => {
     let currentDevice = model.columns[0].devices[0];
-    let outputs: Record<string, any> = {};
+    let outputs: ISampleResults = {};
+    let outputsForAnimation: ISampleResults = {};
     let previousOutputs: Record<string, any> = {};
 
     while (currentDevice) {
       const selectedVariable = getRandomElement(currentDevice.variables);
       let nextDeviceId: string | null = null;
-      const columnName = model.columns.find(column => column.devices.some(device => device.id === currentDevice.id))?.name || "";
+      const columnName = model.columns.find(column => column.devices.find(device => device.id === currentDevice.id))?.name || "";
 
       for (const [deviceId, formula] of Object.entries(currentDevice.formulas)) {
         if (formula === "*") {
@@ -77,6 +79,7 @@ export const useCodapAPI = () => {
       if (columnName) {
         outputs[columnName] = selectedVariable;
         previousOutputs[columnName] = selectedVariable;
+        outputsForAnimation[currentDevice.id] = selectedVariable;
       }
 
       if (nextDeviceId) {
@@ -88,14 +91,16 @@ export const useCodapAPI = () => {
       }
     }
 
-    return outputs;
+    return {outputs, outputsForAnimation};
   };
 
   const getResults = async (experimentNum: number, startingSampleNumber: number) => {
-    const results: { [key: string]: string|number }[] = [];
+    const results: IExperimentResults = [];
+    const resultsForAnimation: IExperimentResultsForAnimation = [];
     const firstDevice = model.columns[0].devices[0];
     const endSampleNumber = startingSampleNumber + Number(numSamples);
     for (let sampleIndex = startingSampleNumber; sampleIndex < endSampleNumber; sampleIndex++) {
+      const sampleResultsForAnimation = [];
       for (let i = 0; i <  Number(sampleSize); i++) {
         const sample: { [key: string]: string|number } = {};
         sample[attrMap.experiment.name] = experimentNum;
@@ -103,15 +108,17 @@ export const useCodapAPI = () => {
         const deviceStr = firstDevice.viewType.charAt(0).toUpperCase() + firstDevice.viewType.slice(1);
         sample[attrMap.description.name] = `${deviceStr} containing ${numSamples} items${replacement ? " (with replacement)" : ""}`;
         sample[attrMap.sample_size.name] = sampleSize && parseInt(sampleSize, 10);
-        const result = await runExperiment();
-        Object.keys(result).forEach(key => {
-          sample[key] = result[key];
+        const {outputs, outputsForAnimation} = await runExperiment();
+        Object.keys(outputs).forEach(key => {
+          sample[key] = outputs[key];
         });
+        sampleResultsForAnimation.push({sampleNumber: sampleIndex, results: outputsForAnimation});
         results.push(sample);
       }
+      resultsForAnimation.push(sampleResultsForAnimation);
     }
 
-    return results;
+    return {results, resultsForAnimation};
   };
 
 
@@ -221,21 +228,19 @@ export const useCodapAPI = () => {
       draft.isRunning = true;
     });
 
-    run();
-  };
+    const attrNames = model.columns.map(column => column.name);
+    await findOrCreateDataContext(attrNames);
 
-  const run = async () => {
     const experimentNum = model.experimentNum
     ? createNewExperiment
         ? model.experimentNum + 1
         : model.experimentNum
     : 1;
+
     const startingSampleNumber = createNewExperiment ? 1 : model.mostRecentRunNumber + 1;
-    const results = await getResults(experimentNum, startingSampleNumber);
-    const attrNames = model.columns.map(column => column.name);
-    const ctxRes = await findOrCreateDataContext(attrNames);
-    if (ctxRes === "success") {
-      await createItems(kDataContextName, results);
+    const {results, resultsForAnimation} = await getResults(experimentNum, startingSampleNumber);
+
+    const onEndRun = () => {
       setGlobalState(draft => {
         draft.model.experimentNum = experimentNum;
         draft.enableRunButton = true;
@@ -243,7 +248,10 @@ export const useCodapAPI = () => {
         draft.model.mostRecentRunNumber = model.mostRecentRunNumber + Number(numSamples);
         draft.isRunning = false;
       });
-    }
+    };
+
+    const animationSteps = createAnimationSteps(resultsForAnimation, results, onEndRun);
+    setAnimationSteps(animationSteps);
   };
 
   const deleteAll = () => {

--- a/src/hooks/useGlobalState.tsx
+++ b/src/hooks/useGlobalState.tsx
@@ -29,7 +29,9 @@ export const getDefaultState = (): IGlobalState => {
     dataContexts: [],
     samplerContext: undefined,
     collectorContext: undefined,
-    modelIsRunning: false
+    isRunning: false,
+    isPaused: false,
+    speed: 1
   };
 };
 

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -18,6 +18,20 @@ export interface AttrMap {
   [key: string]: IAttrForMap;
 }
 
+export enum Speed {
+  Slow = 0,
+  Medium = 1,
+  Fast = 2,
+  Fastest = 3
+}
+
+export const speedLabels: Record<Speed, string> = {
+  [Speed.Slow]: "Slow",
+  [Speed.Medium]: "Medium",
+  [Speed.Fast]: "Fast",
+  [Speed.Fastest]: "Fastest"
+};
+
 export interface IGlobalState {
   model: IModel;
   selectedDeviceId: Id | undefined;
@@ -32,7 +46,9 @@ export interface IGlobalState {
   dataContexts: Array<IDataContext>;
   collectorContext: IDataContext | undefined;
   samplerContext: IDataContext | undefined;
-  modelIsRunning: boolean;
+  isRunning: boolean;
+  isPaused: boolean;
+  speed: Speed;
 }
 
 export interface ICollection {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -34,7 +34,6 @@ export const speedLabels: Record<Speed, string> = {
 
 export type DeviceAnimationStep = {
   kind: "device",
-  duration: number,
   id: Id,
   selectedVariable: string,
 };
@@ -48,7 +47,6 @@ export type FinalAnimationStep = {
 };
 
 export type AnimationStep = {
-  duration: number,
   onComplete?: (() => Promise<void>) | (() => void),
 } & (DeviceAnimationStep | ArrowAnimationStep | FinalAnimationStep);
 

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -34,7 +34,9 @@ export const speedLabels: Record<Speed, string> = {
 
 export type DeviceAnimationStep = {
   kind: "device",
-  id: Id
+  duration: number,
+  id: Id,
+  selectedVariable: string,
 };
 
 export type ArrowAnimationStep = {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -32,6 +32,24 @@ export const speedLabels: Record<Speed, string> = {
   [Speed.Fastest]: "Fastest"
 };
 
+export type DeviceAnimationStep = {
+  kind: "device",
+  id: Id
+};
+
+export type ArrowAnimationStep = {
+  kind: "arrow"
+};
+
+export type FinalAnimationStep = {
+  kind: "final"
+};
+
+export type AnimationStep = {
+  duration: number,
+  onComplete?: (() => Promise<void>) | (() => void),
+} & (DeviceAnimationStep | ArrowAnimationStep | FinalAnimationStep);
+
 export interface IGlobalState {
   model: IModel;
   selectedDeviceId: Id | undefined;
@@ -50,6 +68,14 @@ export interface IGlobalState {
   isPaused: boolean;
   speed: Speed;
 }
+
+export type ISampleResultsForAnimation = {
+  sampleNumber: number,
+  results: ISampleResults
+};
+export type IExperimentResultsForAnimation = ISampleResultsForAnimation[][];
+export type ISampleResults = {[key: string]: any};
+export type IExperimentResults = ISampleResults[];
 
 export interface ICollection {
   areParentChildLinksConfigured: boolean,


### PR DESCRIPTION
This PR adds a hook and state property to manage animations during a run.

So far, the aspects of animation addressed are:
- The CODAP table opens when a run is first begun
- The speed determines the length of each step of the animation
- The speed can be adjusted during a run and this affects the look of the mixer animation
- The mixer animates during a run in the same way as the old Sampler
- After each sample is collected, results are sent to the CODAP table
- Controls are disabled while animation is running

Some remaining tasks to be done:
- If user sets speed to "fastest" during run, all remaining item need to be sent to CODAP
- Animating spinner during a run
- Animating variables moving into position below the column name
- Animating variables moving into brackets (also create the brackets component)
- Animating arrows in order

