### PR TITLE
build: Set webpack-dev-server allowedHosts to all

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ module.exports = (env, argv) => {
     context: __dirname, // to automatically find tsconfig.json
     devServer: {
       static: 'dist',
+      allowedHosts: 'all',
       hot: true,
       https: {
         key: path.resolve(os.homedir(), '.localhost-ssl/localhost.key'),


### PR DESCRIPTION
This allows ngok (or other localhost tunnels) to serve the plugin over https.