### PR TITLE
fix: Ball animation collision detection [PT-187271307]

### DIFF
--- a/src/components/model/device-views/shared/constants.ts
+++ b/src/components/model/device-views/shared/constants.ts
@@ -10,3 +10,7 @@ export const kSpinnerContainerHeight = 209;
 export const kSpinnerRadius = Math.min(kMixerContainerWidth, kMixerContainerHeight) / 2;
 export const kSpinnerX = (kContainerX / 2) + (kSpinnerContainerWidth / 2); //x center of spinner
 export const kSpinnerY = (kContainerY / 2) + (kSpinnerContainerHeight / 2); //y center of spinner
+export const kContainerCollisionTop = kContainerY + kBorder;
+export const kContainerCollisionLeft = kContainerX + kBorder;
+export const kContainerCollisionRight = kContainerCollisionLeft + kMixerContainerWidth - kBorder;
+export const kContainerCollisionBottom = kContainerCollisionTop + kMixerContainerHeight - kBorder;


### PR DESCRIPTION
This centralizes the collision detection and fixes a boundary error in the previous calculation.

NOTE: this also disables the final css translation of the balls to animate to their starting positions. This will be reenabled when the animation loop is updated at which time we will know when the animation completely stops.  The current code calls moveBackToInitialPositions at the end of each sample instead of at the end of all the samples.