### PR TITLE
fix: Added missing boolean word operators for formula formatter [PT-187221915]

### DIFF
--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -58,4 +58,12 @@ describe("formatFormula", () => {
     const expected3 = "output2 + output2 > 6";
     expect(formatFormula(expression3, columnName3, replacements3)).toBe(expected3);
   });
+
+  it("should handle boolean word operators", () => {
+    const expression = "a and b or c and rand or ror";
+    const columnName = "output";
+    const replacements = ["output"];
+    const expected = "output = 'a' and 'b' or 'c' and 'rand' or 'ror'";
+    expect(formatFormula(expression, columnName, replacements)).toBe(expected);
+  });
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -72,6 +72,8 @@ export function parseSpecifier(spec: string, rangeWord: string) {
   return arr.length? arr : null;
 }
 
+const booleanWordOperatorRegex = /^(and|or)$/i;
+
 export const formatFormula = (expression: string, columnName: string, replacements: string[]): string => {
   // remove  quotes from the expression
   let cleanedExpression = expression.replace(/"/g, '').replace(/'/g, '');
@@ -79,7 +81,7 @@ export const formatFormula = (expression: string, columnName: string, replacemen
   // the formulaEngine function from the CODAP API expects string values to be wrapped with single quotes
   // for example, if the expression is "output = a", the formula passed to the API should be "output = 'a'"
   const wrapVariables = (match: string) => {
-    return replacements.includes(match) ? match : `'${match}'`;
+    return replacements.includes(match) || booleanWordOperatorRegex.test(match) ? match : `'${match}'`;
   };
 
   const variableAndOperatorPattern = /([a-zA-Z_]\w*)|([\+\-\*\/%<>=!]+)/g;


### PR DESCRIPTION
The "and" and "or" boolean word operators were being escaped to strings in the formula formatter.