### PR TITLE
fix: Update experiment number when device type is changed [PT-187181825]

### DIFF
--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -106,6 +106,9 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
     setGlobalState(draft => {
       const deviceToUpdate = draft.model.columns[columnIndex].devices.find(dev => dev.id === selectedDeviceId);
       if (deviceToUpdate) {
+        if (deviceToUpdate.viewType !== view) {
+          draft.createNewExperiment = true;
+        }
         deviceToUpdate.viewType = view;
       }
     });


### PR DESCRIPTION
This ensures the experiment number is updated when the device type is changed.

However there is a larger problem here - we are using a flag for when to create a new experiment instead of storing something like the hash of the model as a hidden column in the CODAP table and checking if the model already exists.  This needs to be fixed after discussing with Bill.