### PR TITLE
fix: Restore formula to just saving the value [PT-187221915]

### DIFF
--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -48,7 +48,7 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
             targets.forEach((target) => {
               // add a formula if it doesn't exist
               if (!dev.formulas[target.id]) {
-                dev.formulas[target.id] = {value: "*", valid: true};
+                dev.formulas[target.id] = "*";
               }
             });
             // check if there are any formulas that are no longer needed

--- a/src/components/model/formula-editor.tsx
+++ b/src/components/model/formula-editor.tsx
@@ -20,10 +20,11 @@ export const FormulaEditor = ({source, target, columnIndex, arrowMidPoint, svgWi
   const [formula, setFormula] = useState(source.formulas[target.id]);
   const labelRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const [formulaValid, setFormulaValid] = useState(validateFormula(source.formulas[target.id]));
 
   const resetLabelInput = useCallback(() => {
     if (inputRef.current) {
-      inputRef.current.value = formula.value;
+      inputRef.current.value = formula;
     }
   }, [formula]);
 
@@ -40,20 +41,20 @@ export const FormulaEditor = ({source, target, columnIndex, arrowMidPoint, svgWi
   const handleUpdateLabel = useCallback(() => {
     const trimmedLabel = (inputRef.current?.value ?? "").trim();
     if (trimmedLabel.length > 0) {
-      const newFormula = {value: trimmedLabel, valid: validateFormula(trimmedLabel)};
-      setFormula(newFormula);
+      setFormula(trimmedLabel);
+      setFormulaValid(validateFormula(trimmedLabel));
       setGlobalState(draft => {
         const sourceIdx = draft.model.columns[columnIndex].devices.findIndex(d => d.id === source.id);
-        draft.model.columns[columnIndex].devices[sourceIdx].formulas[target.id] = newFormula;
+        draft.model.columns[columnIndex].devices[sourceIdx].formulas[target.id] = trimmedLabel;
       });
       handleToggleEditing();
     } else {
       if (inputRef.current) {
         inputRef.current.value = "*";
-        setFormula({value: "*", valid: true});
+        setFormula("*");
       }
     }
-  }, [source.id, target.id, columnIndex, setFormula, setGlobalState]);
+  }, [source.id, target.id, columnIndex, setFormula, setFormulaValid, setGlobalState]);
 
   useEffect(() => {
     const handleMouseUp = (e: MouseEvent) => {
@@ -99,16 +100,16 @@ export const FormulaEditor = ({source, target, columnIndex, arrowMidPoint, svgWi
     <div ref={labelRef} className="arrow-label" style={labelStyle}>
       { editing
         ? <form className="label-form" onSubmit={handleSubmitEdit}>
-            <input disabled={isRunning} type="text" ref={inputRef} defaultValue={formula.value} onKeyDown={handleLabelKeyDown}
+            <input disabled={isRunning} type="text" ref={inputRef} defaultValue={formula} onKeyDown={handleLabelKeyDown}
                 style={{height: kMaxLabelHeight}}/>
           </form>
         : <div
-            className={`label-span ${source.id} ${isRunning ? "disabled" : ""} ${!formula.valid ? "invalid" : ""}`}
+            className={`label-span ${source.id} ${isRunning ? "disabled" : ""} ${!formulaValid ? "invalid" : ""}`}
             tabIndex={0}
             onKeyDown={handleToggleEditing}
             onClick={isRunning ? undefined : handleToggleEditing}
           >
-            {formula.value}
+            {formula}
           </div>
       }
     </div>

--- a/src/hooks/useCodapAPI.tsx
+++ b/src/hooks/useCodapAPI.tsx
@@ -56,12 +56,12 @@ export const useCodapAPI = () => {
       const columnName = model.columns.find(column => column.devices.find(device => device.id === currentDevice.id))?.name || "";
 
       for (const [deviceId, formula] of Object.entries(currentDevice.formulas)) {
-        if (formula.value === "*") {
+        if (formula === "*") {
           nextDeviceId = deviceId;
           break;
         }
 
-        const neededVariables = extractVariablesFromFormula(formula.value);
+        const neededVariables = extractVariablesFromFormula(formula);
         const values = neededVariables.reduce((acc, variable) => {
           if (variable in previousOutputs) {
               acc[variable] = previousOutputs[variable];
@@ -69,7 +69,7 @@ export const useCodapAPI = () => {
           return acc;
         }, { [columnName]: selectedVariable });
 
-        const formattedFormula = formatFormula(formula.value, columnName, Object.keys(values));
+        const formattedFormula = formatFormula(formula, columnName, Object.keys(values));
         const evaluationResult = await evaluateResult(formattedFormula, values);
         if (evaluationResult) {
           nextDeviceId = deviceId;

--- a/src/models/device-model.tsx
+++ b/src/models/device-model.tsx
@@ -13,7 +13,7 @@ export interface IDevice {
   viewType: View;
   variables: IVariables;
   collectorVariables: ICollectorVariables;
-  formulas: Record<string, {value: string, valid: boolean}>;
+  formulas: Record<string, string>;
 }
 
 // a map of variables to their percentages


### PR DESCRIPTION
The change in the work that validated the formula caused an object to be output for the formula with the value and the valid flag. This caused old files not to be loaded without a migration.  Since the valid flag can be computed there is no need to store it so the formula save state was returned to just be the value.