### PR TITLE
fix: Update spinner wedge dragging [PT-187636438]

### DIFF
--- a/src/components/model/device-views/spinner/separator-lines.tsx
+++ b/src/components/model/device-views/spinner/separator-lines.tsx
@@ -1,26 +1,71 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { kSpinnerX, kSpinnerY } from "../shared/constants";
 import { getCoordinatesForPercent } from "../shared/helpers";
+import { useGlobalStateContext } from "../../../../hooks/useGlobalState";
 
 interface IWedge {
   percent: number;
   lastPercent: number;
+  varArrayIdx: number;
+  isDragging: boolean;
+  handleSetSelectedVariable?: (variableIdx: number) => void;
+  handleStartDrag?: (originPt: {x: number; y: number;}) => void;
 }
 
-export const SeparatorLine = ({percent, lastPercent}: IWedge) => {
+export const SeparatorLine = ({percent, lastPercent, varArrayIdx, isDragging, handleSetSelectedVariable, handleStartDrag}: IWedge) => {
+  const { globalState: { isRunning } } = useGlobalStateContext();
   const [edgePath, setEdgePath] = useState("");
+  const [style, setStyle] = useState<React.CSSProperties|undefined>(undefined);
+  const [hovering, setHovering] = useState(false);
+
+  const p1 = useMemo(() => getCoordinatesForPercent(lastPercent), [lastPercent]);
+  const p2 = useMemo(() => getCoordinatesForPercent(lastPercent + percent), [lastPercent, percent]);
+
+  const canDrag = useMemo(() => !!(!isRunning && handleSetSelectedVariable && handleStartDrag), [isRunning, handleSetSelectedVariable, handleStartDrag]);
 
   useEffect(() => {
-    const perc2 = lastPercent + percent;
-    const p2 = getCoordinatesForPercent(perc2);
     setEdgePath(`M ${kSpinnerX} ${kSpinnerY} L ${p2[0]} ${p2[1]}`);
-  }, [percent, lastPercent]);
+  }, [p1, p2]);
+
+  useEffect(() => {
+    if (isDragging) {
+      setStyle({cursor: "grabbing"});
+    } else if (canDrag) {
+      setStyle({cursor: "pointer"});
+    } else {
+      setStyle(undefined);
+    }
+  }, [canDrag, isDragging]);
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if (canDrag) {
+      handleSetSelectedVariable?.(varArrayIdx);
+      handleStartDrag?.({x: p1[0], y: p1[1]});
+    }
+  };
+
+  const handleMouseEnter = () => setHovering(true);
+  const handleMouseLeave = () => setHovering(false);
 
   return (
-    <path
-      d={edgePath}
-      stroke={"#FFF"}
-      strokeWidth={1}
-    />
+    <>
+      {hovering && <circle cx={kSpinnerX} cy={kSpinnerY} r={5} fill="#fff" style={{pointerEvents: "none"}} />}
+      {canDrag && <path
+        d={edgePath}
+        stroke={"#000"}
+        strokeWidth={10}
+        opacity={0}
+        onMouseDown={handleMouseDown}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        style={style}
+      />}
+      <path
+        d={edgePath}
+        stroke={"#FFF"}
+        strokeWidth={hovering ? 4 : 1}
+        style={{pointerEvents: "none"}}
+      />
+    </>
   );
 };

--- a/src/components/model/device-views/spinner/spinner.tsx
+++ b/src/components/model/device-views/spinner/spinner.tsx
@@ -116,17 +116,23 @@ export const Spinner = ({device, selectedVariableIdx, isDragging, handleSetSelec
               handleSetEditingVarName={handleSetEditingVarName}
               handleSetEditingPct={handleSetEditingPct}
               handleDeleteWedge={handleDeleteWedge}
-              handleStartDrag={handleStartDrag}
             />
           );
         })}
+        {isDragging && <circle cx={kSpinnerX} cy={kSpinnerY} r={5} fill="#fff" />}
         {[...new Set(variables)].map((variableName, index) => {
+          const varArrayIdx = variables.findIndex((v) => v === variableName);
           const {lastPercent, currPercent} = getCurrentAndLastPct(variableName, index);
+          const isLastVariable = index === [...new Set(variables)].length - 1;
           return (
             <SeparatorLine
               key={`${id}-separator-line-${variableName}-${index}`}
               percent={currPercent}
               lastPercent={lastPercent}
+              varArrayIdx={varArrayIdx}
+              isDragging={isDragging}
+              handleSetSelectedVariable={isLastVariable ? undefined : handleSetSelectedVariable}
+              handleStartDrag={isLastVariable ? undefined : handleStartDrag}
             />
           );
         })}

--- a/src/components/model/device-views/spinner/wedge.tsx
+++ b/src/components/model/device-views/spinner/wedge.tsx
@@ -23,7 +23,6 @@ interface IWedge {
   handleDeleteWedge: (e: React.MouseEvent, variableName: string) => void;
   handleSetEditingPct: () => void;
   handleSetEditingVarName: (variableIdx: number) => void
-  handleStartDrag: (originPt: {x: number; y: number;}) => void;
 }
 
 const kDarkTeal = "#008cba";
@@ -49,7 +48,7 @@ const getEllipseCoords = (percent: number) => {
 
 export const Wedge = ({percent, lastPercent, index, variableName, labelFontSize, numUniqueVariables,
   varArrayIdx, selectedWedge, isLastVariable, isDragging, deviceId, handleSetSelectedVariable, handleDeleteWedge,
-  handleSetEditingPct, handleSetEditingVarName, handleAddDefs, handleStartDrag}: IWedge) => {
+  handleSetEditingPct, handleSetEditingVarName, handleAddDefs}: IWedge) => {
   const { globalState: { isRunning } } = useGlobalStateContext();
   const [wedgePath, setWedgePath] = useState("");
   const [wedgeColor, setWedgeColor] = useState(selectedWedge === variableName ? kDarkTeal : "");
@@ -57,8 +56,6 @@ export const Wedge = ({percent, lastPercent, index, variableName, labelFontSize,
   const [labelLinePath, setLabelLinePath] = useState("");
   const [pctPos, setPctPos] = useState<{x: number, y: number}>({x: 0, y: 0});
   const [delBtnPos, setDelBtnPos] = useState<{x: number, y: number}>({x: 0, y: 0});
-  const [edgePath, setEdgePath] = useState("");
-  const [point1, setPoint1] = useState<{x: number, y: number}>({x: 0, y: 0});
   const [textBackerPos, setTextBackerPos] = useState<ITextBackerPos|undefined>(undefined);
 
   useEffect(() => {
@@ -92,8 +89,6 @@ export const Wedge = ({percent, lastPercent, index, variableName, labelFontSize,
     setPctPos({x: pctLabelLoc[0], y: pctLabelLoc[1]});
     setLabelLinePath(`M ${labelLineP1.join(" ")} L ${labelLineP2.join(" ")}`);
     setDelBtnPos({x: pctLabelLoc[0], y: deleteBtnLocY});
-    setEdgePath(`M ${kSpinnerX} ${kSpinnerY} L ${p2[0]} ${p2[1]}`);
-    setPoint1({x: p1[0], y: p1[1]});
     const color = selectedWedge === variableName ? kDarkTeal : getVariableColor(index, 2, false);
     setWedgeColor(color);
 
@@ -115,12 +110,6 @@ export const Wedge = ({percent, lastPercent, index, variableName, labelFontSize,
   const handleWedgeClick = (e: React.MouseEvent) => {
     if (isRunning) return;
     handleSetSelectedVariable(varArrayIdx);
-  };
-
-  const handleMouseDown = (e: React.MouseEvent) => {
-    if (isRunning) return;
-    handleSetSelectedVariable(varArrayIdx);
-    handleStartDrag({x: point1.x, y: point1.y});
   };
 
   const buttonSize = 15;
@@ -165,18 +154,6 @@ export const Wedge = ({percent, lastPercent, index, variableName, labelFontSize,
       >
         {variableName}
       </text>
-      {/* draggable edge */}
-      { !isLastVariable &&
-        <path
-          id={`${deviceId}-wedge-edge-${variableName}`}
-          d={edgePath}
-          stroke={wedgeColor}
-          strokeWidth={10}
-          style={{cursor: isRunning ? "default" : isDragging ? "grabbing" : "grab"}}
-          onMouseDown={handleMouseDown}
-          clipPath={`url(#${deviceId}-wedge-clip-${variableName}`}
-        />
-      }
       { selectedWedge === variableName &&
         <>
           {/* percentage label */}


### PR DESCRIPTION
This moves the drag handler to the edges between wedges and creates a wide click/hover path under the visible path to make it easier to select.  This also updates the visible path to be wider on hover/select and adds a center round element to let the user know the edge is draggable.