### PR TITLE
fix: Moved all types to the types.ts file

### DIFF
--- a/src/components/helpers.ts
+++ b/src/components/helpers.ts
@@ -1,5 +1,4 @@
-import { IVariables } from "../models/device-model";
-import { IColumn } from "../models/model-model";
+import { IVariables, IColumn, IGetNewPcts } from "../types";
 
 export function calcPct (a: number, b: number) {
   return Math.round(100 * (a / b));
@@ -122,14 +121,6 @@ export const getFirstAndLastIndexOfVar = (variable: string, variables: IVariable
   const lastIndexOfVar = (variables.filter(v => v === variable).length - 1) + firstIndexOfVar;
   return {firstIndexOfVar, lastIndexOfVar};
 };
-
-interface IGetNewPcts {
-  newPct: number;
-  oldPct: number;
-  selectedVar: string;
-  variables: IVariables;
-  updateNext?: boolean;
-}
 
 export const getNewPcts = ({newPct, oldPct, selectedVar, variables, updateNext}: IGetNewPcts) => {
   const diffOfPcts = newPct - oldPct;

--- a/src/components/model/arrow.tsx
+++ b/src/components/model/arrow.tsx
@@ -1,17 +1,11 @@
 import React, { useEffect, useState } from "react";
 import { useGlobalStateContext } from "../../hooks/useGlobalState";
-import { IDevice } from "../../models/device-model";
 import { useResizer } from "../../hooks/use-resizer";
 import { FormulaEditor } from "./formula-editor";
 import { useAnimationContext } from "../../hooks/useAnimation";
-import { AnimationStep, IAnimationStepSettings } from "../../types";
+import { AnimationStep, IAnimationStepSettings, IDevice, IPoint } from "../../types";
 
 import "./arrow.scss";
-
-interface IPoint {
-  x: number
-  y: number;
-}
 
 interface IProps {
   source: IDevice

--- a/src/components/model/column-header.tsx
+++ b/src/components/model/column-header.tsx
@@ -1,11 +1,10 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useGlobalStateContext } from "../../hooks/useGlobalState";
-import { IColumn } from "../../models/model-model";
 import { getAttribute, updateAttribute } from "@concord-consortium/codap-plugin-api";
 import { kDataContextName } from "../../contants";
 import { getNewColumnName } from "../helpers";
 import { useAnimationContext } from "../../hooks/useAnimation";
-import { AnimationStep, IAnimationStepSettings } from "../../types";
+import { AnimationStep, IAnimationStepSettings, IColumn } from "../../types";
 
 interface IProps {
   column: IColumn;

--- a/src/components/model/column.tsx
+++ b/src/components/model/column.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { useGlobalStateContext } from "../../hooks/useGlobalState";
 import { Device } from "./device";
-import { IColumn, getSourceDevices } from "../../models/model-model";
+import { getSourceDevices } from "../../models/model-model";
 import { Arrow } from "./arrow";
 import { ColumnHeader } from "./column-header";
-
+import { IColumn } from "../../types";
 
 import "./model-component.scss";
 

--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -1,15 +1,16 @@
 import React from "react";
-import { IDataContext, IDevice, IVariables, ViewType, createDefaultDevice } from "../../models/device-model";
+import { createDefaultDevice } from "../../models/device-model";
 import { useGlobalStateContext } from "../../hooks/useGlobalState";
 import { getNumDevices, getSiblingDevices, getTargetDevices } from "../../models/model-model";
 import { getNewColumnName, getNewVariable, getProportionalVars } from "../helpers";
 import { createNewAttribute } from "@concord-consortium/codap-plugin-api";
 import { kDataContextName } from "../../contants";
 import { createId } from "../../utils/id";
+import { IDataContext, IDevice, IVariables, ViewType } from "../../types";
 
 import "./device-footer.scss";
 
-interface IDeviceFooter {
+interface IProps {
   device: IDevice;
   columnIndex: number;
   dataContexts: IDataContext[];
@@ -19,7 +20,7 @@ interface IDeviceFooter {
   handleSpecifyVariables: () => void;
 }
 
-export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handleDeleteVariable, handleSelectDataContext, handleSpecifyVariables, dataContexts}: IDeviceFooter) => {
+export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handleDeleteVariable, handleSelectDataContext, handleSpecifyVariables, dataContexts}: IProps) => {
   const { globalState, setGlobalState } = useGlobalStateContext();
   const { model, selectedDeviceId, isRunning } = globalState;
   const { viewType } = device;

--- a/src/components/model/device-views/collector.tsx
+++ b/src/components/model/device-views/collector.tsx
@@ -1,16 +1,16 @@
 import React, { useEffect, useState } from "react";
-import { ClippingDef, IDevice } from "../../../models/device-model";
 import { MixerFrame } from "./shared/mixer-frame";
 import { Balls } from "./shared/balls";
+import { IDevice, ClippingDef } from "../../../types";
 
-interface ICollector {
+interface IProps {
   device: IDevice;
   handleAddDefs: (def: ClippingDef) => void
   handleSetSelectedVariable: (variableIdx: number) => void;
   handleSetEditingVarName: (variableIdx: number) => void;
 }
 
-export const Collector = ({device, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName}: ICollector) => {
+export const Collector = ({device, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName}: IProps) => {
   const [ballsArray, setBallsArray] = useState<Array<string>>([]);
   const { collectorVariables, id: deviceId } = device;
 

--- a/src/components/model/device-views/mixer.tsx
+++ b/src/components/model/device-views/mixer.tsx
@@ -1,16 +1,16 @@
 import React from "react";
-import { ClippingDef, IDevice } from "../../../models/device-model";
 import { MixerFrame } from "./shared/mixer-frame";
 import { Balls } from "./shared/balls";
+import { ClippingDef, IDevice } from "../../../types";
 
-interface IMixer {
+interface IProps {
   device: IDevice;
   handleAddDefs: (def: ClippingDef) => void;
   handleSetSelectedVariable: (variableIdx: number) => void;
   handleSetEditingVarName: (variableIdx: number) => void;
 }
 
-export const Mixer = ({device, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName}: IMixer) => {
+export const Mixer = ({device, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName}: IProps) => {
   const { variables, id: deviceId } = device;
   return (
     <>

--- a/src/components/model/device-views/shared/ball.tsx
+++ b/src/components/model/device-views/shared/ball.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from "react";
 import { getTextShift, getVariableColor } from "./helpers";
-import { ClippingDef } from "../../../../models/device-model";
 import { useGlobalStateContext } from "../../../../hooks/useGlobalState";
+import { ClippingDef } from "../../../../types";
 
-export interface IBall {
+interface IProps {
   x: number;
   y: number;
   transform: string;
@@ -19,7 +19,7 @@ export interface IBall {
 }
 
 export const Ball = ({ x, y, transform, radius, text, fontSize,
-  handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName, i, deviceId, visibility }: IBall) => {
+  handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName, i, deviceId, visibility }: IProps) => {
   const { globalState: { isRunning } } = useGlobalStateContext();
 
   useEffect(() => {

--- a/src/components/model/device-views/shared/balls.tsx
+++ b/src/components/model/device-views/shared/balls.tsx
@@ -1,37 +1,15 @@
 import React, { useEffect, useRef, useState } from "react";
 import { kBorder, kCapHeight, kMixerContainerHeight, kMixerContainerWidth, kContainerX, kContainerY, kContainerCollisionBottom, kContainerCollisionLeft, kContainerCollisionRight, kContainerCollisionTop } from "./constants";
-import { ClippingDef, ICollectorItem } from "../../../../models/device-model";
 import { Ball } from "./ball";
 import { useAnimationContext } from "../../../../hooks/useAnimation";
-import { IAnimationStepSettings, AnimationStep } from "../../../../types";
+import { IAnimationStepSettings, AnimationStep, ClippingDef, ICollectorItem, IBallPosition, IFinalPosition, IFinalPositionInput } from "../../../../types";
 
-interface IBalls {
+interface IProps {
   ballsArray: Array<string>;
   deviceId: string;
   handleAddDefs: (def: ClippingDef) => void;
   handleSetSelectedVariable: (variableIdx: number) => void;
   handleSetEditingVarName:  (variableIdx: number) => void;
-}
-
-interface IBallPosition {
-  x: number;
-  y: number;
-  vy: number;
-  vx: number;
-  transform: string;
-  visibility: "visible" | "hidden";
-}
-
-interface IFinalPosition {
-  x: number;
-  y: number;
-  vy: number;
-  vx: number;
-  radius: number;
-}
-interface IFinalPositionInput extends IFinalPosition {
-  dx: number;
-  dy: number;
 }
 
 const animateToExitT = 0.5;
@@ -140,7 +118,7 @@ const getCycledPositions = (positions: IBallPosition[], selectedVariableIdx: num
   });
 };
 
-export const Balls = ({ballsArray, deviceId, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName}: IBalls) => {
+export const Balls = ({ballsArray, deviceId, handleAddDefs, handleSetSelectedVariable, handleSetEditingVarName}: IProps) => {
   const { registerAnimationCallback } = useAnimationContext();
   const [ballPositions, setBallPositions] = useState<Array<IBallPosition>>([]);
 

--- a/src/components/model/device-views/spinner/needle.tsx
+++ b/src/components/model/device-views/spinner/needle.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { kSpinnerRadius, kSpinnerX, kSpinnerY } from "../shared/constants";
 import { getCoordinatesForPercent } from "../shared/helpers";
 import { useAnimationContext } from "../../../../hooks/useAnimation";
-import { AnimationStep, IAnimationStepSettings } from "../../../../types";
+import { AnimationStep, IAnimationStepSettings, IVariableLocation } from "../../../../types";
 
 const needleNorthLength = kSpinnerRadius * 2/3;
 const needleSouthLength = kSpinnerRadius / 5;
@@ -16,11 +16,6 @@ const path = `M ${n.join(" ")} L ${e.join(" ")} L ${so.join(" ")} L ${w.join(" "
 interface IProps {
   deviceId: string;
   variableLocations: Record<string,IVariableLocation>;
-}
-
-export interface IVariableLocation {
-  lastPercent: number;
-  currPercent: number;
 }
 
 export const Needle = ({deviceId, variableLocations}: IProps) => {

--- a/src/components/model/device-views/spinner/separator-lines.tsx
+++ b/src/components/model/device-views/spinner/separator-lines.tsx
@@ -3,7 +3,7 @@ import { kSpinnerX, kSpinnerY } from "../shared/constants";
 import { getCoordinatesForPercent } from "../shared/helpers";
 import { useGlobalStateContext } from "../../../../hooks/useGlobalState";
 
-interface IWedge {
+interface IProps {
   percent: number;
   lastPercent: number;
   varArrayIdx: number;
@@ -12,7 +12,7 @@ interface IWedge {
   handleStartDrag?: (originPt: {x: number; y: number;}) => void;
 }
 
-export const SeparatorLine = ({percent, lastPercent, varArrayIdx, isDragging, handleSetSelectedVariable, handleStartDrag}: IWedge) => {
+export const SeparatorLine = ({percent, lastPercent, varArrayIdx, isDragging, handleSetSelectedVariable, handleStartDrag}: IProps) => {
   const { globalState: { isRunning } } = useGlobalStateContext();
   const [edgePath, setEdgePath] = useState("");
   const [style, setStyle] = useState<React.CSSProperties|undefined>(undefined);

--- a/src/components/model/device-views/spinner/spinner.tsx
+++ b/src/components/model/device-views/spinner/spinner.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { ClippingDef, IDevice } from "../../../../models/device-model";
 import { kSpinnerRadius, kSpinnerX, kSpinnerY } from "../shared/constants";
 import { getTextShift, getVariableColor } from "../shared/helpers";
 import { Wedge } from "./wedge";
 import { SeparatorLine } from "./separator-lines";
 import { useGlobalStateContext } from "../../../../hooks/useGlobalState";
-import { ITextBackerPos, TextBacker, updateTextBackerRefFn } from "./text-backer";
-import { IVariableLocation, Needle } from "./needle";
+import { TextBacker, updateTextBackerRefFn } from "./text-backer";
+import { Needle } from "./needle";
+import { ClippingDef, IDevice, ITextBackerPos, IVariableLocation } from "../../../../types";
 
-interface ISpinner {
+interface IProps {
   device: IDevice;
   selectedVariableIdx: number|null;
   isDragging: boolean;
@@ -21,7 +21,7 @@ interface ISpinner {
 }
 
 export const Spinner = ({device, selectedVariableIdx, isDragging, handleSetSelectedVariable, handleDeleteWedge,
-  handleSetEditingPct, handleSetEditingVarName, handleAddDefs, handleStartDrag}: ISpinner) => {
+  handleSetEditingPct, handleSetEditingVarName, handleAddDefs, handleStartDrag}: IProps) => {
   const { globalState: { isRunning } } = useGlobalStateContext();
   const [selectedWedge, setSelectedWedge] = useState<string|null>(null);
   const { variables, id } = device;

--- a/src/components/model/device-views/spinner/text-backer.tsx
+++ b/src/components/model/device-views/spinner/text-backer.tsx
@@ -1,17 +1,11 @@
 import React from "react";
 import { useGlobalStateContext } from "../../../../hooks/useGlobalState";
+import { ITextBackerPos } from "../../../../types";
 
-interface ITextBacker {
+interface IProps {
   pos?: ITextBackerPos;
   onClick: () => void;
   isDragging: boolean;
-}
-
-export interface ITextBackerPos {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
 }
 
 export const updateTextBackerRefFn = (setTextBackerPos: (value: React.SetStateAction<ITextBackerPos | undefined>) => void) => (svgText: SVGTextElement | null) => {
@@ -28,7 +22,7 @@ export const updateTextBackerRefFn = (setTextBackerPos: (value: React.SetStateAc
   });
 };
 
-export const TextBacker = ({pos, onClick, isDragging}: ITextBacker) => {
+export const TextBacker = ({pos, onClick, isDragging}: IProps) => {
   const { globalState: { isRunning } } = useGlobalStateContext();
 
   if (!pos) {

--- a/src/components/model/device-views/spinner/wedge.tsx
+++ b/src/components/model/device-views/spinner/wedge.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from "react";
 import { kSpinnerRadius, kSpinnerX, kSpinnerY } from "../shared/constants";
 import { getCoordinatesForPercent, getTextShift, getVariableColor } from "../shared/helpers";
-import { ClippingDef } from "../../../../models/device-model";
 import { useGlobalStateContext } from "../../../../hooks/useGlobalState";
-import { ITextBackerPos, TextBacker, updateTextBackerRefFn } from "./text-backer";
+import { TextBacker, updateTextBackerRefFn } from "./text-backer";
+import { ClippingDef, ITextBackerPos } from "../../../../types";
 
-interface IWedge {
+interface IProps {
   percent: number;
   lastPercent: number;
   variableName: string;
@@ -45,10 +45,9 @@ const getEllipseCoords = (percent: number) => {
   return [x, y];
 };
 
-
 export const Wedge = ({percent, lastPercent, index, variableName, labelFontSize, numUniqueVariables,
   varArrayIdx, selectedWedge, isLastVariable, isDragging, deviceId, handleSetSelectedVariable, handleDeleteWedge,
-  handleSetEditingPct, handleSetEditingVarName, handleAddDefs}: IWedge) => {
+  handleSetEditingPct, handleSetEditingVarName, handleAddDefs}: IProps) => {
   const { globalState: { isRunning } } = useGlobalStateContext();
   const [wedgePath, setWedgePath] = useState("");
   const [wedgeColor, setWedgeColor] = useState(selectedWedge === variableName ? kDarkTeal : "");

--- a/src/components/model/device.tsx
+++ b/src/components/model/device.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useGlobalStateContext } from "../../hooks/useGlobalState";
-import { ClippingDef, IDataContext, IDevice, IItem, IItems, IVariables, ViewType } from "../../models/device-model";
 import { Mixer } from "./device-views/mixer";
 import { Spinner } from "./device-views/spinner/spinner";
 import { Collector } from "./device-views/collector";
@@ -16,6 +15,7 @@ import { SetVariableSeriesModal } from "./variable-setting-modal";
 import DeleteIcon from "../../assets/delete-icon.svg";
 import VisibleIcon from "../../assets/visibility-on-icon.svg";
 import { parseSpecifier } from "../../utils/utils";
+import { IDevice, IDataContext, ClippingDef, ViewType, IItems, IItem, IVariables } from "../../types";
 
 import "./device.scss";
 

--- a/src/components/model/formula-editor.tsx
+++ b/src/components/model/formula-editor.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { IDevice } from "../../models/device-model";
 import { useGlobalStateContext } from "../../hooks/useGlobalState";
 import { validateFormula } from "../../utils/utils";
+import { IDevice } from "../../types";
 
 interface IProps {
   source: IDevice;

--- a/src/components/model/help-modal.tsx
+++ b/src/components/model/help-modal.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 
-interface IHelpModal {
+interface IProps {
   setShowHelp: (show: boolean) => void;
 }
 
-export const HelpModal = ({setShowHelp}: IHelpModal) => {
+export const HelpModal = ({setShowHelp}: IProps) => {
   const handleCloseModal = () => {
     setShowHelp(false);
   };

--- a/src/components/model/model-component.tsx
+++ b/src/components/model/model-component.tsx
@@ -4,9 +4,9 @@ import { AnimationContext, useAnimationContextValue } from "../../hooks/useAnima
 import { useResizer } from "../../hooks/use-resizer";
 import { Column } from "./column";
 import { ModelHeader } from "./model-header";
+import { Outputs } from "./outputs";
 
 import "./model-component.scss";
-import { Outputs } from "./outputs";
 
 export const ModelTab = () => {
   const { globalState } = useGlobalStateContext();

--- a/src/components/model/model-header.tsx
+++ b/src/components/model/model-header.tsx
@@ -6,14 +6,14 @@ import { useGlobalStateContext } from "../../hooks/useGlobalState";
 import { deleteAll } from "../../helpers/codap-helpers";
 import { useAnimationContext } from "../../hooks/useAnimation";
 
-interface IModelHeader {
+interface IProps {
   showHelp: boolean;
   isWide: boolean;
   setShowHelp: (showHelp: boolean) => void;
   handleOpenHelp: () => void;
 }
 
-export const ModelHeader = (props: IModelHeader) => {
+export const ModelHeader = (props: IProps) => {
   const { showHelp, setShowHelp, isWide, handleOpenHelp } = props;
   const { globalState, setGlobalState } = useGlobalStateContext();
   const { repeat, sampleSize, numSamples, enableRunButton, isRunning, isPaused, attrMap } = globalState;

--- a/src/components/model/name-label-input.tsx
+++ b/src/components/model/name-label-input.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
-import { ViewType } from "../../models/device-model";
+import { ViewType } from "../../types";
 
-interface IVariableLabelInput {
+interface IProps {
   variableIdx: number;
   viewType: ViewType;
   variableName: string;
@@ -11,7 +11,7 @@ interface IVariableLabelInput {
 }
 
 export const NameLabelInput = ({variableIdx, variableName,
-  handleEditVariable, onBlur, viewType, deviceId}: IVariableLabelInput) => {
+  handleEditVariable, onBlur, viewType, deviceId}: IProps) => {
   const [text, setText] = useState<string>(variableName);
   const ref = useRef<HTMLInputElement>(null);
 

--- a/src/components/model/percent-label-input.tsx
+++ b/src/components/model/percent-label-input.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 
-interface IVariableLabelInput {
+interface IProps {
   percent: string;
   variableIdx: number;
   variableName: string;
@@ -10,7 +10,7 @@ interface IVariableLabelInput {
 }
 
 export const PctLabelInput = ({percent, variableIdx, variableName, deviceId,
-  handlePctChange, onBlur}: IVariableLabelInput) => {
+  handlePctChange, onBlur}: IProps) => {
   const [text, setText] = useState<string>(percent);
   const ref = useRef<HTMLInputElement>(null);
 

--- a/src/hooks/use-resizer.ts
+++ b/src/hooks/use-resizer.ts
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
-
-export type ResizerListener = () => void;
+import { ResizerListener } from "../types";
 
 const listeners: ResizerListener[] = [];
 

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -1,28 +1,12 @@
 import { createContext, useContext, useEffect, useRef } from "react";
-import { AnimationCallback, AnimationStep, IAnimationStepSettings, IExperimentResults, IExperimentResultsForAnimation, ISampleResults, RegisterAnimationCallbackFn, Speed } from "../types";
+import { AnimationCallback, AnimationStep, IAnimationContext, IAnimationRuntime, IAnimationStepSettings, IExperimentResults, IExperimentResultsForAnimation, IModel, ISampleResults, Speed } from "../types";
 import { createItems, selectCases } from "@concord-consortium/codap-plugin-api";
 import { kDataContextName } from "../contants";
 import { useGlobalStateContext } from "./useGlobalState";
 import { evaluateResult, findOrCreateDataContext } from "../helpers/codap-helpers";
 import { getRandomElement } from "../components/helpers";
-import { getDeviceById, IModel } from "../models/model-model";
+import { getDeviceById } from "../models/model-model";
 import { extractVariablesFromFormula, formatFormula } from "../utils/utils";
-
-export interface IAnimationContext {
-  handleStartRun: () => Promise<void>
-  handleTogglePauseRun: (pause: boolean) => Promise<void>
-  handleStopRun: () => Promise<void>
-  registerAnimationCallback: RegisterAnimationCallbackFn
-}
-
-interface IAnimationRuntime {
-  frame: number,
-  steps: AnimationStep[],
-  stepIndex: number,
-  elapsed?: number,
-  lastTimestamp?: number,
-  mode: "running"|"paused"|"stopped"
-}
 
 const stepDurations: Partial<Record<AnimationStep["kind"], number>> = {
   "animateDevice": 1200,

--- a/src/hooks/useGlobalState.tsx
+++ b/src/hooks/useGlobalState.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect } from "react";
-import { Updater, useImmer } from "use-immer";
-import { AttrMap, IGlobalState } from "../types";
+import { useImmer } from "use-immer";
+import { AttrMap, IGlobalState, IGlobalStateContext } from "../types";
 import { addDataContextChangeListener, codapInterface, IInitializePlugin, initializePlugin } from "@concord-consortium/codap-plugin-api";
 import { createDefaultDevice } from "../models/device-model";
 import { kDataContextName, kInitialDimensions, kPluginName, kVersion } from "../contants";
@@ -12,7 +12,6 @@ const defaultAttrMap: AttrMap = {
   sample_size: {codapID: null, name: "sample size"},
   sample: {codapID: null, name: "sample"},
 };
-
 
 export const getDefaultState = (): IGlobalState => {
   return {
@@ -35,11 +34,6 @@ export const getDefaultState = (): IGlobalState => {
     speed: 1
   };
 };
-
-export interface IGlobalStateContext {
-  globalState: IGlobalState;
-  setGlobalState: Updater<IGlobalState>;
-}
 
 export const useGlobalStateContextValue = (): IGlobalStateContext => {
   const [globalState, setGlobalState] = useImmer<IGlobalState>(getDefaultState());

--- a/src/models/device-model.tsx
+++ b/src/models/device-model.tsx
@@ -1,57 +1,9 @@
-import { Id, createId } from "../utils/id";
-
-export enum ViewType {
-  Mixer = "mixer",
-  Spinner = "spinner",
-  Collector = "collector"
-}
-
-export type View = ViewType.Mixer | ViewType.Spinner | ViewType.Collector;
-
-export interface IDevice {
-  id: Id;
-  viewType: View;
-  variables: IVariables;
-  collectorVariables: ICollectorVariables;
-  formulas: Record<string, string>;
-}
-
-// a map of variables to their percentages
-// i.e.: { a: 50, b: 50 }
-// the view (mixer / spinner) decides how to best represent these percentages
-export type IVariables = Array<string>;
-// a map of attributes to their values
-// { "Mammal": "Dog", "Color": "Brown"}
-export interface ICollectorItem {
-  [attr: string]: string | number;
-}
-
-// an array of items that come from a linked dataset
-// i.e.: [ { "Mammal": "Dog", "Color": "Brown"}, { "Mammal": "Cat", "Color": "Black"} ]
-// the collector view will represent the values of the first key-value pair of each object in the array
-// i.e., one ball for "Dog", one ball for "Cat"
-// if "Dog" is selected by the collector, the entire item is sent to CODAP
-export type ICollectorVariables = Array<ICollectorItem>;
-export interface IDataContext {
-  guid: number;
-  id: number;
-  name: string;
-  title: string;
-}
-
-export interface IItem {
-  id: number;
-  values: ICollectorItem;
-}
-
-export type IItems = Array<IItem>;
-
-export type ClippingDef = { id: string, element: JSX.Element };
+import { IVariables, IDevice, ViewType } from "../types";
+import { createId } from "../utils/id";
 
 export function gcd(a: number, b: number): number {
   return b === 0 ? a : gcd(b, a % b);
 }
-
 
 export function lcm(a: number, b: number): number {
   return (a * b) / gcd(a, b);

--- a/src/models/model-model.tsx
+++ b/src/models/model-model.tsx
@@ -1,34 +1,4 @@
-import { Id } from "../utils/id";
-import { IDevice } from "./device-model";
-
-export interface IColumn {
-  name: string;
-  id: Id;
-  devices: IDevice[];
-}
-
-export interface IModel {
-  columns: IColumn[];
-  experimentNum: number;
-  mostRecentRunNumber: number;  // Gets reset between experiments, but if the parameters haven't changed we keep incrementing
-  runNumberSentInCurrentSequence: number; // This gets reset when user presses start regardless of whether params have changed
-}
-
-export interface IExperiment {
-  experimentAttr: number;
-  descriptionAttr: string;
-  sampleSizeAttr: number;
-}
-
-export interface ISample {
-  [sampleAttr: string]: number;
-}
-// as model runs, new key-value pairs are added to the result object
-export interface IRunResult {
-  [attr: string]: string | number;
-}
-
-export type DeviceMap = Record<Id,IDevice>;
+import { IModel, IDevice, Id, DeviceMap } from "../types";
 
 export const getNumDevices = (model: IModel): number => {
   return getDevices(model).length;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,6 +1,6 @@
-import { IDataContext } from "./models/device-model";
-import { IModel } from "./models/model-model";
-import { Id } from "./utils/id";
+import { Updater } from "use-immer";
+
+export type Id = string;
 
 const navTabs = ["Model", "Measures", "About"] as const;
 type NavTab = typeof navTabs[number];
@@ -166,4 +166,150 @@ export interface IAttribute {
   renameable?: boolean;
   deleteable?: boolean;
   hidden?: boolean;
+}
+
+export interface IVariableLocation {
+  lastPercent: number;
+  currPercent: number;
+}
+
+export interface ITextBackerPos {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface IAnimationContext {
+  handleStartRun: () => Promise<void>
+  handleTogglePauseRun: (pause: boolean) => Promise<void>
+  handleStopRun: () => Promise<void>
+  registerAnimationCallback: RegisterAnimationCallbackFn
+}
+
+export interface IAnimationRuntime {
+  frame: number,
+  steps: AnimationStep[],
+  stepIndex: number,
+  elapsed?: number,
+  lastTimestamp?: number,
+  mode: "running"|"paused"|"stopped"
+}
+
+export enum ViewType {
+  Mixer = "mixer",
+  Spinner = "spinner",
+  Collector = "collector"
+}
+
+export type View = ViewType.Mixer | ViewType.Spinner | ViewType.Collector;
+
+export interface IDevice {
+  id: Id;
+  viewType: View;
+  variables: IVariables;
+  collectorVariables: ICollectorVariables;
+  formulas: Record<string, string>;
+}
+
+// a map of variables to their percentages
+// i.e.: { a: 50, b: 50 }
+// the view (mixer / spinner) decides how to best represent these percentages
+export type IVariables = Array<string>;
+// a map of attributes to their values
+// { "Mammal": "Dog", "Color": "Brown"}
+export interface ICollectorItem {
+  [attr: string]: string | number;
+}
+
+// an array of items that come from a linked dataset
+// i.e.: [ { "Mammal": "Dog", "Color": "Brown"}, { "Mammal": "Cat", "Color": "Black"} ]
+// the collector view will represent the values of the first key-value pair of each object in the array
+// i.e., one ball for "Dog", one ball for "Cat"
+// if "Dog" is selected by the collector, the entire item is sent to CODAP
+export type ICollectorVariables = Array<ICollectorItem>;
+export interface IDataContext {
+  guid: number;
+  id: number;
+  name: string;
+  title: string;
+}
+
+export interface IItem {
+  id: number;
+  values: ICollectorItem;
+}
+
+export type IItems = Array<IItem>;
+
+export type ClippingDef = { id: string, element: JSX.Element };
+
+export interface IColumn {
+  name: string;
+  id: Id;
+  devices: IDevice[];
+}
+
+export interface IModel {
+  columns: IColumn[];
+  experimentNum: number;
+  mostRecentRunNumber: number;  // Gets reset between experiments, but if the parameters haven't changed we keep incrementing
+  runNumberSentInCurrentSequence: number; // This gets reset when user presses start regardless of whether params have changed
+}
+
+export interface IExperiment {
+  experimentAttr: number;
+  descriptionAttr: string;
+  sampleSizeAttr: number;
+}
+
+export interface ISample {
+  [sampleAttr: string]: number;
+}
+// as model runs, new key-value pairs are added to the result object
+export interface IRunResult {
+  [attr: string]: string | number;
+}
+
+export type DeviceMap = Record<Id,IDevice>;
+
+export interface IGlobalStateContext {
+  globalState: IGlobalState;
+  setGlobalState: Updater<IGlobalState>;
+}
+
+export type ResizerListener = () => void;
+
+export interface IBallPosition {
+  x: number;
+  y: number;
+  vy: number;
+  vx: number;
+  transform: string;
+  visibility: "visible" | "hidden";
+}
+
+export interface IFinalPosition {
+  x: number;
+  y: number;
+  vy: number;
+  vx: number;
+  radius: number;
+}
+export interface IFinalPositionInput extends IFinalPosition {
+  dx: number;
+  dy: number;
+}
+
+export interface IPoint {
+  x: number
+  y: number;
+}
+
+export interface IGetNewPcts {
+  newPct: number;
+  oldPct: number;
+  selectedVar: string;
+  variables: IVariables;
+  updateNext?: boolean;
 }

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,4 +1,4 @@
-export type Id = string;
+import { Id } from "../types";
 
 const idChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 export const createId = (): Id => {


### PR DESCRIPTION
I was refactoring the code to allow for experiments without replacement and hit a type import cycle.  Instead of adding to the complexity of that PR this PR just centralizes all the types into one file to remove the import cycle.