### PR TITLE
feat: Use hidden experiment hash to track experiment and sample number [PT-188267656]

### DIFF
--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -89,8 +89,6 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
           }
         }
       }
-      draft.model.mostRecentRunNumber = 0;
-      draft.createNewExperiment = true;
     });
     updateFormulas();
   };
@@ -98,8 +96,6 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
   const handleMergeDevices = () => {
     setGlobalState(draft => {
       draft.model.columns[columnIndex].devices.splice(0, model.columns[columnIndex].devices.length, device);
-      draft.model.mostRecentRunNumber = 0;
-      draft.createNewExperiment = true;
     });
     updateFormulas();
   };
@@ -108,9 +104,6 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
     setGlobalState(draft => {
       const deviceToUpdate = draft.model.columns[columnIndex].devices.find(dev => dev.id === selectedDeviceId);
       if (deviceToUpdate) {
-        if (deviceToUpdate.viewType !== view) {
-          draft.createNewExperiment = true;
-        }
         deviceToUpdate.viewType = view;
       }
     });

--- a/src/components/model/device.tsx
+++ b/src/components/model/device.tsx
@@ -16,6 +16,7 @@ import DeleteIcon from "../../assets/delete-icon.svg";
 import VisibleIcon from "../../assets/visibility-on-icon.svg";
 import { parseSpecifier } from "../../utils/utils";
 import { IDevice, IDataContext, ClippingDef, ViewType, IItems, IItem, IVariables } from "../../types";
+import { removeDeviceFromFormulas } from "../../helpers/model-helpers";
 
 import "./device.scss";
 
@@ -95,6 +96,8 @@ export const Device = (props: IProps) => {
       const hasColumnsToTheRight = draft.model.columns.length > columnIndex + 1;
       const question = noMoreDevicesInThisColumn && hasColumnsToTheRight ? "Delete this device and all the devices to the right of it?" : "Delete this device?";
       if (confirm(question)) {
+        removeDeviceFromFormulas(draft.model, device.id);
+
         if (noMoreDevicesInThisColumn) {
           // when last device in a column is deleted delete this column and all the devices to the right if they exist
           draft.model.columns.splice(columnIndex, draft.model.columns.length - columnIndex);
@@ -103,8 +106,6 @@ export const Device = (props: IProps) => {
           draft.model.columns[columnIndex].devices = devices;
         }
       }
-      draft.model.mostRecentRunNumber = 0;
-      draft.createNewExperiment = true;
     });
   };
 
@@ -146,8 +147,6 @@ export const Device = (props: IProps) => {
       if (deviceToUpdate) {
         deviceToUpdate.variables = newVariables;
       }
-      draft.model.mostRecentRunNumber = 0;
-      draft.createNewExperiment = true;
     });
   }, [selectedDeviceId, setGlobalState, columnIndex]);
 

--- a/src/components/model/model-header.tsx
+++ b/src/components/model/model-header.tsx
@@ -33,27 +33,17 @@ export const ModelHeader = (props: IProps) => {
   };
 
   const handleClearData = () => {
-    setGlobalState(draft => {
-      draft.model.mostRecentRunNumber = 0;
-      draft.createNewExperiment = true;
-    });
     deleteAll(attrMap);
   };
 
   const handleSelectRepeat = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setGlobalState(draft => {
       draft.repeat = e.target.value === "repeat";
-      draft.model.mostRecentRunNumber = 0;
-      draft.createNewExperiment = true;
     });
   };
 
   const handleSampleSizeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setGlobalState(draft => {
-      if (draft.sampleSize !== e.target.value) {
-        draft.model.mostRecentRunNumber = 0;
-        draft.createNewExperiment = true;
-      }
       if (e.target.value !== null && Number(e.target.value)) {
         draft.enableRunButton = true;
       } else {
@@ -71,10 +61,6 @@ export const ModelHeader = (props: IProps) => {
 
   const handleNumSamplesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setGlobalState(draft => {
-      if (draft.numSamples !== e.target.value) {
-        draft.model.mostRecentRunNumber = 0;
-        draft.createNewExperiment = true;
-      }
       if (e.target.value !== null && Number(e.target.value)) {
         draft.enableRunButton = true;
       } else {
@@ -112,6 +98,7 @@ export const ModelHeader = (props: IProps) => {
         {repeat &&
           <div className={`repeat-until-controls ${isWide ? "wide" : ""}`}>
             <span>until</span>
+            {/* note: when this feature is implemented the model-helpers#computeExperimentHash method needs to be updated to include the until value */}
             <input type="text"></input>
             <InfoIcon onClick={handleOpenHelp}/>
             {showHelp && <HelpModal setShowHelp={setShowHelp}/>}

--- a/src/helpers/model-helpers.ts
+++ b/src/helpers/model-helpers.ts
@@ -1,4 +1,4 @@
-import { IModel } from "../types";
+import { Id, IGlobalState, IModel } from "../types";
 
 export const modelHasSpinner = (model: IModel) => {
   return model.columns.reduce<boolean>((acc, column) => {
@@ -7,3 +7,53 @@ export const modelHasSpinner = (model: IModel) => {
     }, acc);
   }, false);
 };
+
+export const computeExperimentHash = async (globalState: IGlobalState): Promise<string> => {
+  const {model, repeat, replacement, sampleSize, numSamples} = globalState;
+
+  const signature = model.columns.reduce<string[]>((acc, column) => {
+    acc.push(JSON.stringify(column));
+    return acc;
+  }, [])
+  .concat(JSON.stringify({repeat, replacement, sampleSize, numSamples}))
+  .join("+");
+
+  const encoder = new TextEncoder();
+  const data = encoder.encode(signature);
+  const hashBuffer = await crypto.subtle.digest('SHA-1', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+
+  return hashHex;
+};
+
+export const removeDeviceFromFormulas = (model: IModel, deviceId: Id) => {
+  model.columns.forEach(column => {
+    column.devices.forEach(d => {
+      if (d.formulas?.[deviceId]) {
+        delete d.formulas[deviceId];
+      }
+    });
+  });
+};
+
+export const removeMissingDevicesFromFormulas = (model: IModel) => {
+  const deviceIds = model.columns.reduce<string[]>((acc, column) => {
+    return column.devices.reduce<string[]>((acc2, device) => {
+      acc2.push(device.id);
+      return acc2;
+    }, acc);
+  }, []);
+
+  model.columns.forEach(column => {
+    column.devices.forEach(d => {
+      d.formulas = Object.keys(d.formulas).reduce<Record<string,string>>((acc, key) => {
+        if (deviceIds.includes(key)) {
+          acc[key] = d.formulas[key];
+        }
+        return acc;
+      }, {});
+    });
+  });
+};
+

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -14,6 +14,7 @@ export interface AttrMap {
   experiment: IAttrForMap;
   description: IAttrForMap;
   sample_size: IAttrForMap;
+  experimentHash: IAttrForMap;
   sample: IAttrForMap;
   [key: string]: IAttrForMap;
 }
@@ -120,7 +121,6 @@ export interface IGlobalState {
   replacement: boolean;
   sampleSize: string;
   numSamples: string;
-  createNewExperiment: boolean;
   enableRunButton: boolean;
   attrMap: AttrMap;
   dataContexts: Array<IDataContext>;
@@ -256,9 +256,6 @@ export interface IColumn {
 
 export interface IModel {
   columns: IColumn[];
-  experimentNum: number;
-  mostRecentRunNumber: number;  // Gets reset between experiments, but if the parameters haven't changed we keep incrementing
-  runNumberSentInCurrentSequence: number; // This gets reset when user presses start regardless of whether params have changed
 }
 
 export interface IExperiment {


### PR DESCRIPTION
This replaces some complex state flags with a hidden hash of the experiment contained in the data table.

This also fixes a bug where the formulas kept references to deleted device ids.  This caused experiments to hash incorrectly when devices were deleted.