### PR TITLE
fix: The user can scroll the contents of the Sampler plugin [SAMPLER-18]

### DIFF
--- a/src/components/App.scss
+++ b/src/components/App.scss
@@ -8,6 +8,7 @@
   bottom: 0;
   right: 0;
   left: 0;
+  overflow: auto;
 
   button {
     &:hover:not(:disabled):not(.disabled) {


### PR DESCRIPTION
Added overflow: auto to App class.