### PR TITLE
fix: Rename variables in functions when column is renamed [SAMPLER-24]

### DIFF
--- a/src/components/model/column-header.tsx
+++ b/src/components/model/column-header.tsx
@@ -5,6 +5,7 @@ import { kDataContextName } from "../../contants";
 import { getNewColumnName } from "../helpers";
 import { useAnimationContext } from "../../hooks/useAnimation";
 import { AnimationStep, IAnimationStepSettings, IColumn } from "../../types";
+import { renameAttributeInFormulas } from "../../helpers/codap-helpers";
 
 interface IProps {
   column: IColumn;
@@ -48,6 +49,7 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
       const oldAttrName = globalState.attrMap[column.id].name;
       const attr = (await getAttribute(kDataContextName, "items", oldAttrName)).values;
       await updateAttribute(kDataContextName, "items", oldAttrName, attr, {name: newName});
+      await renameAttributeInFormulas(kDataContextName, oldAttrName, newName);
       setColumnName(newName);
       setGlobalState(draft => {
         draft.model.columns[columnIndex].name = newName;

--- a/src/utils/formula-parser.ts
+++ b/src/utils/formula-parser.ts
@@ -321,3 +321,40 @@ export const getVariables = (parsedFormula: ExpressionNode): string[] => {
   extractVariables(parsedFormula, variableSet);
   return Array.from(variableSet);
 };
+
+export const renameVariable = (parsedFormula: ExpressionNode, oldName: string, newName: string): ExpressionNode => {
+  switch (parsedFormula.type) {
+    case "BinaryExpression":
+      return {
+        type: "BinaryExpression",
+        operator: parsedFormula.operator,
+        left: renameVariable(parsedFormula.left, oldName, newName),
+        right: renameVariable(parsedFormula.right, oldName, newName),
+      };
+    case "UnaryExpression":
+      return {
+        type: "UnaryExpression",
+        operator: parsedFormula.operator,
+        argument: renameVariable(parsedFormula.argument, oldName, newName),
+      };
+    case "Literal":
+      return parsedFormula;
+    case "Variable":
+      return {
+        type: "Variable",
+        name: parsedFormula.name === oldName ? newName : parsedFormula.name,
+      };
+    case "FunctionCall":
+      return {
+        type: "FunctionCall",
+        callee: parsedFormula.callee,
+        arguments: parsedFormula.arguments.map(arg => renameVariable(arg, oldName, newName)),
+      };
+    case "GroupingExpression":
+      return {
+        type: "GroupingExpression",
+        expression: renameVariable(parsedFormula.expression, oldName, newName),
+      };
+  }
+};
+


### PR DESCRIPTION
This uses the existing formula parser to parse any formula found in the data context and a new function to rename the variable in the parsed result.