### PR TITLE
fix: Allow device name input to resize [SAMPLER-6]

### DIFF
--- a/src/components/model/device.scss
+++ b/src/components/model/device.scss
@@ -1,5 +1,4 @@
 .device-controls-container {
-  position: relative;
   top: 25px;
   &.multiple-columns {
     top: 52px;

--- a/src/components/model/model-component.scss
+++ b/src/components/model/model-component.scss
@@ -319,21 +319,22 @@ $pluginMinWidth: 304px;
       flex-direction: column;
     }
     .device-column-header {
-      margin: 5px;
-      position: absolute;
-      top: 0;
+      margin: 5px 0 20px 0;
 
       .attr-name {
-        width: 40px;
-        margin: 0 70px 8px;
+        width: auto;
         border-radius: 1.5px;
         border: solid 1px #8f8f9d;
         background-color: #fff;
+        text-align: center;
+        resize: none;
       }
 
       .device-column-header-label {
         font-size: 16px;
         font-weight: 500;
+        position: absolute;
+        width: 100%;
       }
     }
   }


### PR DESCRIPTION
This changes the device name input to a textarea that defaults to 1 row but auto resizes to match the input.

This also fixes a bug that I noticed where users could clear the input field and set the variable name to the empty string.  Now if the user tries to do that and "blurs" the input to save it the column name is reset.