### PR TITLE
fix: Allow multiple samplers [SAMPLER-10]

### DIFF
--- a/src/components/measures/measures.tsx
+++ b/src/components/measures/measures.tsx
@@ -22,7 +22,7 @@ const getFormula = (measure: Measure, left: string, op: string, right: string) =
 };
 
 export const MeasuresTab = () => {
-  const { globalState: { model: { columns } } } = useGlobalStateContext();
+  const { globalState: { model: { columns }, dataContextName } } = useGlobalStateContext();
   const [selectedMeasure, setSelectedMeasure] = useState<Measure>("default");
   const [measureName, setMeasureName] = useState("");
   const [lValue, setLValue] = useState("");
@@ -32,11 +32,11 @@ export const MeasuresTab = () => {
 
   useEffect(() => {
     const checkForSamples = async () => {
-      const result = await hasSamplesCollection();
+      const result = await hasSamplesCollection(dataContextName);
       setHasSamples(result);
     };
     checkForSamples();
-  }, []);
+  }, [dataContextName]);
 
   const disableAddButton = useMemo(() => {
     let disable = selectedMeasure === "default" || lValue.length === 0;  // measureName is optional
@@ -73,7 +73,7 @@ export const MeasuresTab = () => {
 
   const handleAddMeasure = () => {
     const formula = getFormula(selectedMeasure, lValue, opValue, rValue);
-    addMeasure(measureName, selectedMeasure, formula);
+    addMeasure(dataContextName, measureName, selectedMeasure, formula);
   };
 
   const renderAttributes = () => {

--- a/src/components/model/column-header.tsx
+++ b/src/components/model/column-header.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useGlobalStateContext } from "../../hooks/useGlobalState";
 import { getAttribute, updateAttribute } from "@concord-consortium/codap-plugin-api";
-import { kDataContextName } from "../../contants";
 import { getNewColumnName } from "../helpers";
 import { useAnimationContext } from "../../hooks/useAnimation";
 import { AnimationStep, IAnimationStepSettings, IColumn } from "../../types";
@@ -64,10 +63,11 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
     }
 
     if (globalState.samplerContext) {
+      const dataContextName = globalState.samplerContext.name;
       const oldAttrName = globalState.attrMap[column.id].name;
-      const attr = (await getAttribute(kDataContextName, "items", oldAttrName)).values;
-      await updateAttribute(kDataContextName, "items", oldAttrName, attr, {name: newName});
-      await renameAttributeInFormulas(kDataContextName, oldAttrName, newName);
+      const attr = (await getAttribute(dataContextName, "items", oldAttrName)).values;
+      await updateAttribute(dataContextName, "items", oldAttrName, attr, {name: newName});
+      await renameAttributeInFormulas(dataContextName, oldAttrName, newName);
       setColumnName(newName);
       setGlobalState(draft => {
         draft.model.columns[columnIndex].name = newName;

--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -4,7 +4,6 @@ import { useGlobalStateContext } from "../../hooks/useGlobalState";
 import { getNumDevices, getSiblingDevices, getTargetDevices } from "../../models/model-model";
 import { getNewColumnName, getNewVariable, getProportionalVars } from "../helpers";
 import { createNewAttribute } from "@concord-consortium/codap-plugin-api";
-import { kDataContextName } from "../../contants";
 import { createId } from "../../utils/id";
 import { IDataContext, IDevice, IVariables, ViewType } from "../../types";
 
@@ -87,7 +86,7 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
         } else {
           draft.attrMap[id] = {name, codapID: null};
           if (draft.samplerContext) {
-            createNewAttribute(kDataContextName, "items", name);
+            createNewAttribute(draft.samplerContext.name, "items", name);
           }
         }
       }

--- a/src/components/model/device.tsx
+++ b/src/components/model/device.tsx
@@ -7,7 +7,6 @@ import { NameLabelInput } from "./name-label-input";
 import { PctLabelInput } from "./percent-label-input";
 import { DeviceFooter } from "./device-footer";
 import { kMixerContainerHeight, kMixerContainerWidth, kSpinnerContainerHeight, kSpinnerContainerWidth, kSpinnerX, kSpinnerY } from "./device-views/shared/constants";
-import { kDataContextName } from "../../contants";
 import { getAllItems, getListOfDataContexts } from "@concord-consortium/codap-plugin-api";
 import { createNewVarArray, getNextVariable, getPercentOfVar } from "../helpers";
 import { calculateWedgePercentage } from "./device-views/shared/helpers";
@@ -51,7 +50,7 @@ export const Device = (props: IProps) => {
 
     if (viewType === ViewType.Collector) {
       fetchDataContexts().then((contexts: Array<IDataContext>) => {
-        const filteredCtxs = contexts.filter((context) => context.name !== kDataContextName);
+        const filteredCtxs = contexts.filter((context) => context.name !== globalState.dataContextName);
         setDataContexts(filteredCtxs);
       });
     }
@@ -61,7 +60,7 @@ export const Device = (props: IProps) => {
     } else {
       setViewBox(`0 0 ${kMixerContainerWidth + 10} ${kMixerContainerHeight}`);
     }
-  }, [viewType]);
+  }, [viewType, globalState.dataContextName]);
 
   useEffect(() => {
     if (selectedDataContext) {

--- a/src/components/model/model-header.tsx
+++ b/src/components/model/model-header.tsx
@@ -17,7 +17,7 @@ interface IProps {
 export const ModelHeader = (props: IProps) => {
   const { showHelp, setShowHelp, isWide, handleOpenHelp } = props;
   const { globalState, setGlobalState } = useGlobalStateContext();
-  const { repeat, sampleSize, numSamples, enableRunButton, isRunning, isPaused, attrMap, model, replacement } = globalState;
+  const { repeat, sampleSize, numSamples, enableRunButton, isRunning, isPaused, attrMap, model, replacement, dataContextName } = globalState;
   const { handleStartRun, handleTogglePauseRun, handleStopRun } = useAnimationContext();
   const startToggleDisabled = !isRunning && !enableRunButton;
 
@@ -33,7 +33,7 @@ export const ModelHeader = (props: IProps) => {
   };
 
   const handleClearData = () => {
-    deleteAll(attrMap);
+    deleteAll(dataContextName, attrMap);
   };
 
   const handleSelectRepeat = (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/src/contants.ts
+++ b/src/contants.ts
@@ -1,4 +1,3 @@
-export const kDataContextName = "Sampler";
 export const kPluginMidWidth = 328;
 export const kPluginName = "Sampler";
 export const kVersion = "v0.3.0";

--- a/src/hooks/useGlobalState.tsx
+++ b/src/hooks/useGlobalState.tsx
@@ -3,7 +3,7 @@ import { useImmer } from "use-immer";
 import { AttrMap, IGlobalState, IGlobalStateContext } from "../types";
 import { addDataContextChangeListener, codapInterface, IInitializePlugin, initializePlugin } from "@concord-consortium/codap-plugin-api";
 import { createDefaultDevice } from "../models/device-model";
-import { kDataContextName, kInitialDimensions, kPluginName, kVersion } from "../contants";
+import { kInitialDimensions, kPluginName, kVersion } from "../contants";
 import { createId } from "../utils/id";
 import { migrateModel, removeMissingDevicesFromFormulas } from "../helpers/model-helpers";
 import { ensureMinimumDimensions } from "../helpers/codap-helpers";
@@ -28,6 +28,7 @@ export const getDefaultState = (): IGlobalState => {
     enableRunButton: true,
     attrMap: defaultAttrMap,
     dataContexts: [],
+    dataContextName: "",
     samplerContext: undefined,
     collectorContext: undefined,
     isRunning: false,
@@ -89,7 +90,7 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
 
   useEffect(() => {
     if (globalState.samplerContext) {
-      addDataContextChangeListener(kDataContextName, (msg: any) => {
+      addDataContextChangeListener(globalState.samplerContext.name, (msg: any) => {
         if (msg.values.operation === "updateAttributes") {
           msg.values.result.attrIDs.forEach((id: string, i: number) => {
             const newName = msg.values.result.attrs[i].name;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -123,6 +123,7 @@ export interface IGlobalState {
   numSamples: string;
   enableRunButton: boolean;
   attrMap: AttrMap;
+  dataContextName: string;
   dataContexts: Array<IDataContext>;
   collectorContext: IDataContext | undefined;
   samplerContext: IDataContext | undefined;


### PR DESCRIPTION
This updates the code to store the data context name in the global state and ports the TP-Sampler code that searches for the next available data context name when it needs to create a new data context.