### PR TITLE
fix: Use current device type when Add Device clicked [SAMPLER-33]

### DIFF
--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -65,17 +65,18 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
 
   const handleAddDevice = () => {
     setGlobalState(draft => {
+      const currentDeviceViewType = draft.model.columns[columnIndex].devices[0].viewType;
       const newColumnIndex = columnIndex + 1;
       if (draft.model.columns[newColumnIndex]) {
         // add the device
-        const newDevice = createDefaultDevice();
+        const newDevice = createDefaultDevice(currentDeviceViewType);
         draft.model.columns[newColumnIndex].devices.push(newDevice);
       } else {
         // create the column and add the same number devices as the current column
         const name: string = getNewColumnName("output", model.columns);
         const id: string = createId();
         const numNewDevices = model.columns[columnIndex].devices.length;
-        const newDevices = Array.from({length: numNewDevices}, () => createDefaultDevice());
+        const newDevices = Array.from({length: numNewDevices}, () => createDefaultDevice(currentDeviceViewType));
         draft.model.columns.splice(newColumnIndex, 0, {name, id, devices: newDevices});
         // check if any attrs in attrMap have same name as new column name
         // if so, replace the old attrMap key with the new id

--- a/src/models/device-model.tsx
+++ b/src/models/device-model.tsx
@@ -32,6 +32,6 @@ export function findEquivNum(n: number, lcd: number) {
 }
 
 export const kDefaultVars: IVariables = ["a", "a", "b"];
-export const createDefaultDevice = (): IDevice => {
-  return {id: createId(), viewType: ViewType.Mixer, variables: kDefaultVars, collectorVariables: [], formulas: {}, hidden: false, lockPassword: ""};
+export const createDefaultDevice = (viewType: ViewType = ViewType.Mixer): IDevice => {
+  return {id: createId(), viewType, variables: kDefaultVars, collectorVariables: [], formulas: {}, hidden: false, lockPassword: ""};
 };


### PR DESCRIPTION
Before the mixer device was always added, now the selected device type is added.