### PR TITLE
fix: Update spinner labels [SAMPLER-29]

### DIFF
--- a/src/components/model/device-views/spinner/spinner.tsx
+++ b/src/components/model/device-views/spinner/spinner.tsx
@@ -7,6 +7,7 @@ import { useGlobalStateContext } from "../../../../hooks/useGlobalState";
 import { TextBacker, updateTextBackerRefFn } from "./text-backer";
 import { Needle } from "./needle";
 import { ClippingDef, IDevice, ITextBackerPos, IVariableLocation } from "../../../../types";
+import { TextOverWedge } from "./text-over-wedge";
 
 interface IProps {
   device: IDevice;
@@ -125,12 +126,10 @@ export const Spinner = ({device, selectedVariableIdx, isDragging, handleSetSelec
               lastPercent={lastPercent}
               variableName={variableName}
               index={index}
-              labelFontSize={fontSize}
               varArrayIdx={varArrayIdx}
               selectedWedge={selectedWedge}
               numUniqueVariables={uniqueVariables.length}
               nextVariable={uniqueVariables[index + 1]}
-              isLastVariable={index === uniqueVariables.length - 1}
               isDragging={isDragging}
               handleAddDefs={handleAddDefs}
               handleSetSelectedVariable={handleSetSelectedVariable}
@@ -154,6 +153,30 @@ export const Spinner = ({device, selectedVariableIdx, isDragging, handleSetSelec
               isDragging={isDragging}
               handleSetSelectedVariable={isLastVariable ? undefined : handleSetSelectedVariable}
               handleStartDrag={isLastVariable ? undefined : handleStartDrag}
+            />
+          );
+        })}
+        {uniqueVariables.map((variableName, index) => {
+          const varArrayIdx = variables.findIndex((v) => v === variableName);
+          const {lastPercent, currPercent} = variableLocations[variableName];
+          return (
+            <TextOverWedge
+              key={`${variableName}-${index}`}
+              deviceId={id}
+              percent={currPercent}
+              lastPercent={lastPercent}
+              variableName={variableName}
+              index={index}
+              labelFontSize={fontSize}
+              varArrayIdx={varArrayIdx}
+              selectedWedge={selectedWedge}
+              numUniqueVariables={uniqueVariables.length}
+              nextVariable={uniqueVariables[index + 1]}
+              isLastVariable={index === uniqueVariables.length - 1}
+              isDragging={isDragging}
+              handleAddDefs={handleAddDefs}
+              handleSetSelectedVariable={handleSetSelectedVariable}
+              handleSetEditingVarName={handleSetEditingVarName}
             />
           );
         })}

--- a/src/components/model/device-views/spinner/text-over-wedge.tsx
+++ b/src/components/model/device-views/spinner/text-over-wedge.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from "react";
+import { kSpinnerRadius, kSpinnerX, kSpinnerY } from "../shared/constants";
+import { getTextShift } from "../shared/helpers";
+import { useGlobalStateContext } from "../../../../hooks/useGlobalState";
+import { TextBacker, updateTextBackerRefFn } from "./text-backer";
+import { ClippingDef, ITextBackerPos } from "../../../../types";
+
+interface IProps {
+  percent: number;
+  lastPercent: number;
+  variableName: string;
+  index: number;
+  labelFontSize: number;
+  varArrayIdx: number;
+  numUniqueVariables: number;
+  selectedWedge: string | null;
+  nextVariable: string;
+  isDragging: boolean;
+  isLastVariable: boolean;
+  deviceId: string;
+  handleAddDefs: (def: ClippingDef) => void;
+  handleSetSelectedVariable: (variableIdx: number) => void;
+  handleSetEditingVarName: (variableIdx: number) => void
+}
+
+const getCoordinatesForVariableLabel = (percent: number, numUnique: number) => {
+  const perc = percent + 0.75; // rotate 3/4 to start at top
+  const x = kSpinnerX + (Math.cos(2 * Math.PI * perc) * kSpinnerRadius * (1 + (Math.min(.70, numUnique * 0.1))));
+  const y = kSpinnerY + (Math.sin(2 * Math.PI * perc) * kSpinnerRadius * (1 + (Math.min(.70, numUnique * 0.1))));
+  return [x, y];
+};
+
+export const TextOverWedge = ({percent, lastPercent, index, variableName, labelFontSize, numUniqueVariables,
+  varArrayIdx, selectedWedge, isDragging, deviceId, handleSetSelectedVariable, handleSetEditingVarName, handleAddDefs}: IProps) => {
+  const { globalState: { isRunning } } = useGlobalStateContext();
+  const [labelPos, setLabelPos] = useState<{x: number, y: number}>({x: 0, y: 0});
+  const [textBackerPos, setTextBackerPos] = useState<ITextBackerPos|undefined>(undefined);
+
+  useEffect(() => {
+    const perc2 = lastPercent + percent;
+    const varLabelPosition = getCoordinatesForVariableLabel((lastPercent + perc2)/2, numUniqueVariables);
+
+    setLabelPos({x: (kSpinnerX + varLabelPosition[0]) / 2, y: (kSpinnerY + varLabelPosition[1]) / 2});
+
+  }, [percent, lastPercent, index, variableName, selectedWedge, handleAddDefs, deviceId, varArrayIdx, numUniqueVariables]);
+
+  const handleLabelClick = () => {
+    if (isRunning) return;
+    handleSetEditingVarName(varArrayIdx);
+    handleSetSelectedVariable(varArrayIdx);
+  };
+
+  const fill = !isDragging && selectedWedge ? (selectedWedge === variableName ? "#000" : "#555") : "#000";
+
+  return (
+    <>
+      {/* Safari does not support cursor styling or click handling on svg text elements so this invisible element that
+          is drawn behind the text acts as the styling and click handler source */}
+      <TextBacker pos={textBackerPos} isDragging={isDragging} onClick={handleLabelClick} />
+      {/* variable name label */}
+      <text
+        id={`${deviceId}-wedge-label-${variableName}-${varArrayIdx}`}
+        x={labelPos.x}
+        y={labelPos.y}
+        textAnchor="middle"
+        dy=".25em"
+        dx={getTextShift(variableName, variableName.length)}
+        fill={fill}
+        fontSize={labelFontSize}
+        fontWeight={"normal"}
+        style={{ pointerEvents: "none"}}
+        ref={updateTextBackerRefFn(setTextBackerPos)}
+      >
+        {variableName}
+      </text>
+    </>
+  );
+};

--- a/src/components/model/device-views/spinner/wedge.tsx
+++ b/src/components/model/device-views/spinner/wedge.tsx
@@ -1,22 +1,19 @@
 import React, { useEffect, useState } from "react";
 import { kSpinnerRadius, kSpinnerX, kSpinnerY } from "../shared/constants";
-import { getCoordinatesForPercent, getTextShift, getVariableColor } from "../shared/helpers";
+import { getCoordinatesForPercent, getVariableColor } from "../shared/helpers";
 import { useGlobalStateContext } from "../../../../hooks/useGlobalState";
-import { TextBacker, updateTextBackerRefFn } from "./text-backer";
-import { ClippingDef, ITextBackerPos } from "../../../../types";
+import { ClippingDef } from "../../../../types";
 
 interface IProps {
   percent: number;
   lastPercent: number;
   variableName: string;
   index: number;
-  labelFontSize: number;
   varArrayIdx: number;
   numUniqueVariables: number;
   selectedWedge: string | null;
   nextVariable: string;
   isDragging: boolean;
-  isLastVariable: boolean;
   deviceId: string;
   handleAddDefs: (def: ClippingDef) => void;
   handleSetSelectedVariable: (variableIdx: number) => void;
@@ -28,13 +25,6 @@ interface IProps {
 const kDarkTeal = "#008cba";
 const kLightBlue = "#dbf6ff";
 
-const getCoordinatesForVariableLabel = (percent: number, numUnique: number) => {
-  const perc = percent + 0.75; // rotate 3/4 to start at top
-  const x = kSpinnerX + (Math.cos(2 * Math.PI * perc) * kSpinnerRadius * (1 + (Math.min(.70, numUnique * 0.1))));
-  const y = kSpinnerY + (Math.sin(2 * Math.PI * perc) * kSpinnerRadius * (1 + (Math.min(.70, numUnique * 0.1))));
-  return [x, y];
-};
-
 const getEllipseCoords = (percent: number) => {
   const majorRadius = kSpinnerRadius * 1.3;
   const minorRadius = kSpinnerRadius * 1.25;
@@ -45,24 +35,21 @@ const getEllipseCoords = (percent: number) => {
   return [x, y];
 };
 
-export const Wedge = ({percent, lastPercent, index, variableName, labelFontSize, numUniqueVariables,
-  varArrayIdx, selectedWedge, isLastVariable, isDragging, deviceId, handleSetSelectedVariable, handleDeleteWedge,
+export const Wedge = ({percent, lastPercent, index, variableName, numUniqueVariables,
+  varArrayIdx, selectedWedge, isDragging, deviceId, handleSetSelectedVariable, handleDeleteWedge,
   handleSetEditingPct, handleSetEditingVarName, handleAddDefs}: IProps) => {
   const { globalState: { isRunning } } = useGlobalStateContext();
   const [wedgePath, setWedgePath] = useState("");
   const [wedgeColor, setWedgeColor] = useState(selectedWedge === variableName ? kDarkTeal : "");
-  const [labelPos, setLabelPos] = useState<{x: number, y: number}>({x: 0, y: 0});
   const [labelLinePath, setLabelLinePath] = useState("");
   const [pctPos, setPctPos] = useState<{x: number, y: number}>({x: 0, y: 0});
   const [delBtnPos, setDelBtnPos] = useState<{x: number, y: number}>({x: 0, y: 0});
-  const [textBackerPos, setTextBackerPos] = useState<ITextBackerPos|undefined>(undefined);
 
   useEffect(() => {
     const perc2 = lastPercent + percent;
     const p1 = getCoordinatesForPercent(lastPercent);
     const p2 = getCoordinatesForPercent(perc2);
     const largeArc = perc2 - lastPercent > 0.5 ? 1 : 0;
-    const varLabelPosition = getCoordinatesForVariableLabel((lastPercent + perc2)/2, numUniqueVariables);
     const labelPerc2 = lastPercent + (perc2 - lastPercent) / 2;
     const pctLabelLoc = getEllipseCoords(labelPerc2);
     const labelLineP1 = getCoordinatesForPercent(labelPerc2);
@@ -84,7 +71,6 @@ export const Wedge = ({percent, lastPercent, index, variableName, labelFontSize,
     }
 
     setWedgePath(path);
-    setLabelPos({x: (kSpinnerX + varLabelPosition[0]) / 2, y: (kSpinnerY + varLabelPosition[1]) / 2});
     setPctPos({x: pctLabelLoc[0], y: pctLabelLoc[1]});
     setLabelLinePath(`M ${labelLineP1.join(" ")} L ${labelLineP2.join(" ")}`);
     setDelBtnPos({x: pctLabelLoc[0], y: deleteBtnLocY});
@@ -99,12 +85,6 @@ export const Wedge = ({percent, lastPercent, index, variableName, labelFontSize,
     );
     handleAddDefs({ id: clipPathId, element: clipPath });
   }, [percent, lastPercent, index, variableName, selectedWedge, handleAddDefs, deviceId, varArrayIdx, numUniqueVariables]);
-
-  const handleLabelClick = () => {
-    if (isRunning) return;
-    handleSetEditingVarName(varArrayIdx);
-    handleSetSelectedVariable(varArrayIdx);
-  };
 
   const handleWedgeClick = (e: React.MouseEvent) => {
     if (isRunning) return;
@@ -133,26 +113,6 @@ export const Wedge = ({percent, lastPercent, index, variableName, labelFontSize,
       >
         <title>{Math.round(percent * 100)}%</title>
       </path>
-      {/* Safari does not support cursor styling or click handling on svg text elements so this invisible element that
-          is drawn behind the text acts as the styling and click handler source */}
-      <TextBacker pos={textBackerPos} isDragging={isDragging} onClick={handleLabelClick} />
-      {/* variable name label */}
-      <text
-        id={`${deviceId}-wedge-label-${variableName}-${varArrayIdx}`}
-        x={labelPos.x}
-        y={labelPos.y}
-        textAnchor="middle"
-        dy=".25em"
-        dx={getTextShift(variableName, variableName.length)}
-        fill={selectedWedge === variableName ? "#FFF" : "#000"}
-        fontSize={labelFontSize}
-        fontWeight={selectedWedge === variableName ? "bold" : "normal"}
-        clipPath={`url(#${deviceId}-wedge-clip-${variableName}`}
-        style={{ pointerEvents: "none"}}
-        ref={updateTextBackerRefFn(setTextBackerPos)}
-      >
-        {variableName}
-      </text>
       {/* percentage label */}
       { (isDragging || (selectedWedge === variableName)) &&
         <>


### PR DESCRIPTION
This fixes multiple issues with the spinner component:

- When dragging a wedge all the wedge labels are black
- The spinner label is now displayed over the wedge and separators and is no longer clipped
- When selected the selected wedge label is black and the others are dark gray