### PR TITLE
fix: Clear selected variable on view change [SAMPLER-36]

### DIFF
--- a/src/components/model/device.tsx
+++ b/src/components/model/device.tsx
@@ -133,6 +133,10 @@ export const Device = (props: IProps) => {
     }
   }, [collectorContextName, selectedDeviceId, setGlobalState, columnIndex]);
 
+  useEffect(() => {
+    // when the viewtype changes deselect the selected variable
+    setSelectedVariableIdx(null);
+  }, [viewType]);
 
   const handleSelectDevice = () => {
     setGlobalState(draft => {


### PR DESCRIPTION
This fixes a bug where if you were editing a mixer variable and then selected the spinner the wedge for that variable was automatically selected.