### PR TITLE
fix: Use underscores for blank variables [SAMPLER-37]

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -65,8 +65,10 @@ export function parseSpecifier(spec: string, rangeWord: string) {
       }
     } else {
       if (item !== "") {
-        if (item !== " ") {
+        if (item.trim().length > 0) {
           arr.push(item.trim());
+        } else {
+          arr.push("_");
         }
       }
     }


### PR DESCRIPTION
To match old Sampler plugin use "_" as the variable name when blanks are entered in the "Set Variable Names" dialog.  Previously these were skipped.

Example: the value "a, , b,    , c, d" would result in the following variables: "a, _, b, _, c, d".