### PR TITLE
fix: Change funding image to use float [SAMPLER-38]

### DIFF
--- a/src/components/about/about.scss
+++ b/src/components/about/about.scss
@@ -4,15 +4,12 @@
   font-size: 12px;
 
   .funding {
-    display: flex;
-    gap: 10px;
+    img {
+      float: right;
+    }
 
-    p {
-      margin-top: 0;
-
-      .nsf-grant-id {
-        color: red;
-      }
+    .nsf-grant-id {
+      color: red;
     }
   }
 }

--- a/src/components/about/about.tsx
+++ b/src/components/about/about.tsx
@@ -62,20 +62,15 @@ export const AboutTab = () => {
       </p>
 
       <h2>Funding</h2>
-      <div className="funding">
-        <p>
-          The Sampler in CODAP was inspired by the Sampler in <a href="http://www.tinkerplots.com/" target="_blank" rel="noreferrer">TinkerPlots</a>.
-          It was developed by the <a href="https://concord.org/" target="_blank" rel="noreferrer">Concord Consortium</a> as part of
-          the <a href="https://fi.ncsu.edu/projects/esteem/" target="_blank" rel="noreferrer">ESTEEM project</a> with support by the
-          National Science Foundation under Grant Nos. DUE <span className="nsf-grant-id">1625713</span> and <span className="nsf-grant-id">2141727</span> awarded
-          to North Carolina State University. Any opinions, findings, and conclusions or recommendations in this material are those of the
-          principal investigators and do not necessarily reflect the views of the National Science Foundation.
-        </p>
-        <div>
-          <img src={esteemLogo}></img>
-        </div>
-      </div>
-
+      <p className="funding">
+        <img src={esteemLogo}></img>
+        The Sampler in CODAP was inspired by the Sampler in <a href="http://www.tinkerplots.com/" target="_blank" rel="noreferrer">TinkerPlots</a>.
+        It was developed by the <a href="https://concord.org/" target="_blank" rel="noreferrer">Concord Consortium</a> as part of
+        the <a href="https://fi.ncsu.edu/projects/esteem/" target="_blank" rel="noreferrer">ESTEEM project</a> with support by the
+        National Science Foundation under Grant Nos. DUE <span className="nsf-grant-id">1625713</span> and <span className="nsf-grant-id">2141727</span> awarded
+        to North Carolina State University. Any opinions, findings, and conclusions or recommendations in this material are those of the
+        principal investigators and do not necessarily reflect the views of the National Science Foundation.
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
This is so when the plugin is "skinny" the text wraps around the image instead of staying in its own column.

Before:
![image](https://github.com/user-attachments/assets/9851fdfa-65e2-458d-b242-1b94f14dc2c1)

After:
![image](https://github.com/user-attachments/assets/515ba61a-0c0c-4107-81e6-b665ef5f1c72)
