### PR TITLE
fix: The speed slider should respond to mouse clicks consistently [SAMPLER-40]

### DIFF
--- a/src/components/model/model-component.scss
+++ b/src/components/model/model-component.scss
@@ -61,6 +61,7 @@ $pluginMinWidth: 304px;
         position: absolute;
         left: 8px;
         top: 2px;
+        pointer-events: none;
 
         .tick-mark {
           display: flex;


### PR DESCRIPTION
This fix disables pointer events on the tick marks overlayed on the range input.  The tick marks were preventing the range input from getting clicks.