### PR TITLE
fix: Update number of output brackets [SAMPLER-41]

### DIFF
--- a/src/components/model/outputs.tsx
+++ b/src/components/model/outputs.tsx
@@ -67,10 +67,13 @@ export const Outputs = () => {
 
   const renderEmptyBrackets = () => {
     let numEmptyBrackets = 0;
+    // this is the number of variable brackets currently displayed
     const numVariableBrackets = variables.length + (animatedVariables.length > 0 ? 1 : 0);
     if (repeat) {
+      // for repeat/until show 1 more if we haven't arrived at all the items yet
       numEmptyBrackets = numVariableBrackets < numItems ? 1 : 0;
     } else {
+      // for select show the remaining brackets to fill out the selected sample size
       numEmptyBrackets = Math.max(numItems, parseInt(sampleSize, 10)) - numVariableBrackets;
     }
     const emptyBrackets = [];

--- a/src/components/model/outputs.tsx
+++ b/src/components/model/outputs.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { AnimationStep, IAnimationStepSettings } from "../../types";
 import { useAnimationContext } from "../../hooks/useAnimation";
+import { useGlobalStateContext } from "../../hooks/useGlobalState";
 
 import "./outputs.scss";
 
@@ -11,6 +12,7 @@ const pulse = (t: number, max: number) => t <= 0.5 ? t * max : (1 - t) * max;
 
 export const Outputs = () => {
   const { registerAnimationCallback } = useAnimationContext();
+  const { globalState: { repeat, sampleSize } } = useGlobalStateContext();
   const [ sampleIndex, setSampleIndex ] = useState(0);
   const [ numItems, setNumItems ] = useState(1);
   const [ tValue, setTValue ] = useState(1);
@@ -32,11 +34,11 @@ export const Outputs = () => {
       setPushing(false);
       if (kind === "startExperiment") {
         setSampleIndex(0);
-        setNumItems(step.numItems);
       } else if (kind === "startSample") {
         setVariables([]);
         setAnimatedVariables([]);
         setSampleIndex(step.sampleIndex);
+        setNumItems(step.numItems);
       } else if (kind === "endSelectItem") {
         setVariables(prev => [...prev, step.variables]);
         setAnimatedVariables([]);
@@ -56,14 +58,27 @@ export const Outputs = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-
-  const showEmptyBracket = useMemo(() => (variables.length + animatedVariables.length) < numItems, [numItems, variables, animatedVariables]);
   const insidePushMargin = useMemo(() => pushing ? tValue * maxInsideMargin : 0, [tValue, pushing]);
   const insidePushOpacity = useMemo(() => pushing ? 1 - tValue : 1, [tValue, pushing]);
   const outsidePushMargin = useMemo(() => pushing ? pulse(tValue, maxOutsideMargin) : 0, [tValue, pushing]);
   const animatedVariablesOpacity = useMemo(() => animatedVariables.length > 0 ? tValue : 1, [tValue, animatedVariables]);
 
   const bracket = <div className="outputs-variable-bracket">[</div>;
+
+  const renderEmptyBrackets = () => {
+    let numEmptyBrackets = 0;
+    const numVariableBrackets = variables.length + (animatedVariables.length > 0 ? 1 : 0);
+    if (repeat) {
+      numEmptyBrackets = numVariableBrackets < numItems ? 1 : 0;
+    } else {
+      numEmptyBrackets = Math.max(numItems, parseInt(sampleSize, 10)) - numVariableBrackets;
+    }
+    const emptyBrackets = [];
+    for (let i = 0; i < numEmptyBrackets; i++) {
+      emptyBrackets.push(<div className="outputs-variable" key={i}>{bracket}</div>);
+    }
+    return emptyBrackets;
+  };
 
   return (
     <div className="outputs">
@@ -79,7 +94,7 @@ export const Outputs = () => {
             {bracket}<div style={{opacity: animatedVariablesOpacity}}>{animatedVariables.join(", ")}</div>
           </div>
         )}
-        {showEmptyBracket && <div className="outputs-variable" key="empty">{bracket}</div>}
+        {renderEmptyBrackets()}
       </div>
     </div>
   );

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -22,10 +22,10 @@ const stepDurations: Partial<Record<AnimationStep["kind"], number>> = {
 
 export const createExperimentAnimationSteps = (model: IModel, dataContextName: string, animationResults: IExperimentAnimationResults, results: IExperimentResults, replacement: boolean, onComplete?: () => void): Array<AnimationStep> => {
   const steps: AnimationStep[] = [];
-  steps.push({ kind: "startExperiment", numSamples: animationResults.length, numItems: animationResults[0]?.length ?? 0 });
+  steps.push({ kind: "startExperiment", numSamples: animationResults.length });
 
   animationResults.forEach((sample, sampleIndex) => {
-    steps.push({ kind: "startSample", sampleIndex });
+    steps.push({ kind: "startSample", sampleIndex, numItems: sample.length });
 
     sample.forEach((run) => {
       steps.push({ kind: "startSelectItem" });

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -40,7 +40,6 @@ export type ModelChangedAnimationStep = {
 export type StartExperimentAnimationStep = {
   kind: "startExperiment",
   numSamples: number
-  numItems: number
 };
 export type EndExperimentAnimationStep = {
   kind: "endExperiment"
@@ -48,6 +47,7 @@ export type EndExperimentAnimationStep = {
 export type StartSampleAnimationStep = {
   kind: "startSample"
   sampleIndex: number;
+  numItems: number
 };
 export type EndSampleAnimationStep = {
   kind: "endSample"


### PR DESCRIPTION
In select mode the number of output brackets now match the number of items.  In repeat mode an empty output bracket is maintained until the repeat condition is true.