### PR TITLE
fix: Stack overflow when animating many items in "Fastest" mode [SAMPLER-42]

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -89,7 +89,7 @@ export type LabelAnimationStep = {
 
 
 export type AnimationStep = {
-  onComplete?: (() => Promise<void>) | (() => void),
+  onComplete?: ((settings: IAnimationStepSettings) => Promise<void>) | (() => void),
 } & (
   ModelChangedAnimationStep |
   StartExperimentAnimationStep |


### PR DESCRIPTION
This switches from recursively calling animation() in "Fastest"" mode (which was causing a stack overflow for large number of items) to checking if the animation should instantly complete when requesting a new animation frame.