### PR TITLE
fix: Attribute name change not being handled correctly [SAMPLER-32]

### DIFF
--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -87,7 +87,14 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
         } else {
           draft.attrMap[id] = {name, codapID: null};
           if (draft.samplerContext) {
-            createNewAttribute(draft.samplerContext.name, "items", name);
+            createNewAttribute(draft.samplerContext.name, "items", name)
+              .then((result) => {
+                if (result.success && result.values.attrs?.[0]?.id) {
+                  setGlobalState(draft2 => {
+                    draft2.attrMap[id].codapID = result.values.attrs[0].id;
+                  });
+                }
+              });
           }
         }
       }

--- a/src/components/model/device.tsx
+++ b/src/components/model/device.tsx
@@ -155,7 +155,12 @@ export const Device = (props: IProps) => {
 
         if (noMoreDevicesInThisColumn) {
           // when last device in a column is deleted delete this column and all the devices to the right if they exist
-          draft.model.columns.splice(columnIndex, draft.model.columns.length - columnIndex);
+          const removedColumns = draft.model.columns.splice(columnIndex, draft.model.columns.length - columnIndex);
+
+          // and remove all the attrMap entries for the removed columns
+          removedColumns.forEach(removedColumn => {
+            delete draft.attrMap[removedColumn.id];
+          });
         }
         else {
           draft.model.columns[columnIndex].devices = devices;


### PR DESCRIPTION
This fixes two things which were causing name changes for newly added devices to not be handled correctly.

1. It saves the CODAP id of the item when a new device is created
2. It removes the saved item attributes of any deleted columns.

With these changes notifications from CODAP on an attribute change can find the correct column to update.