### PR TITLE
feat: Keep item attributes in sync with device changes [SAMPLER-30]

### DIFF
--- a/src/components/model/column-header.tsx
+++ b/src/components/model/column-header.tsx
@@ -5,6 +5,7 @@ import { getNewColumnName } from "../helpers";
 import { useAnimationContext } from "../../hooks/useAnimation";
 import { AnimationStep, IAnimationStepSettings, IColumn } from "../../types";
 import { renameAttributeInFormulas } from "../../helpers/codap-helpers";
+import { isCollectorOnlyModel } from "../../utils/collector";
 
 interface IProps {
   column: IColumn;
@@ -14,7 +15,7 @@ interface IProps {
 export const ColumnHeader = ({column, columnIndex}: IProps) => {
   const { globalState, setGlobalState } = useGlobalStateContext();
   const { registerAnimationCallback } = useAnimationContext();
-  const { model, isRunning } = globalState;
+  const { model, isRunning, collectorContextName } = globalState;
   const [columnName, setColumnName] = useState(column.name);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const [label, setLabel] = useState("");
@@ -112,7 +113,7 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
         ref={inputRef}
         disabled={isRunning || isCollector}
         className="attr-name"
-        value={columnName}
+        value={isCollectorOnlyModel(model) ? collectorContextName : columnName}
         onChange={(e) => setColumnName(e.target.value)}
         onKeyDown={(e) => handleKeyDown(e)}
         onBlur={handleNameChange}

--- a/src/components/model/model-header.tsx
+++ b/src/components/model/model-header.tsx
@@ -7,6 +7,7 @@ import { deleteAllItems, deleteItemAttrs, findOrCreateDataContext, getItemAttrs 
 import { useAnimationContext } from "../../hooks/useAnimation";
 import { modelHasSpinner } from "../../helpers/model-helpers";
 import { getCollectorAttrs, isCollectorOnlyModel } from "../../utils/collector";
+import { getModelAttrs } from "../../utils/model";
 
 interface IProps {
   showHelp: boolean;
@@ -43,7 +44,7 @@ export const ModelHeader = (props: IProps) => {
         if (isCollector) {
           newAttrs = getCollectorAttrs(model);
         } else {
-          newAttrs = model.columns.map(column => column.name);
+          newAttrs = getModelAttrs(model);
         }
         const attrsToDelete = existingAttrs.filter(attr => !newAttrs.includes(attr));
 

--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -39,7 +39,7 @@ export const evaluateResult = async (formula: string, value: Record<string, stri
   throw new Error("Formula evaluation failed");
 };
 
-const getCollectionNames = () => {
+export const getCollectionNames = () => {
   return {
     experiments: "experiments",
     samples: "samples",
@@ -240,7 +240,8 @@ export const deleteAllItems = async (dataContextName: string) => {
 };
 
 export const getItemAttrs = async (dataContextName: string): Promise<string[]> => {
-  return (await getAttributeList(dataContextName, getCollectionNames().items)).values.map((attr: any) => attr.name);
+  const result = await getAttributeList(dataContextName, getCollectionNames().items);
+  return result.success ? result.values.map((attr: any) => attr.name) : [];
 };
 
 export const deleteItemAttrs = async (dataContextName: string, attrs: string[]) => {

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -9,6 +9,7 @@ import { computeExperimentHash, modelHasSpinner } from "../helpers/model-helpers
 import { getVariables } from "../utils/formula-parser";
 import { getCollectorAttrs, getCollectorFirstNameVariables, isCollectorOnlyModel } from "../utils/collector";
 import { evaluatePattern, isPattern } from "../utils/pattern";
+import { getModelAttrs } from "../utils/model";
 
 // maximum number of items to collect before stopping when the repeat until formula is not satisfied
 const maxRepeatUntilItems = 1000;
@@ -366,7 +367,7 @@ export const useAnimationContextValue = (): IAnimationContext => {
   const handleStartRun = async () => {
     try {
       const isCollector = isCollectorOnlyModel(model);
-      const attrNames = isCollector ? getCollectorAttrs(model) : model.columns.map(column => column.name);
+      const attrNames = isCollector ? getCollectorAttrs(model) : getModelAttrs(model);
       const finalDataContextName = await findOrCreateDataContext(dataContextName, attrNames, attrMap, setGlobalState, repeat, isCollector);
       if (!finalDataContextName) {
         alert("Unable to setup CODAP table");

--- a/src/utils/collector.ts
+++ b/src/utils/collector.ts
@@ -20,8 +20,5 @@ export const isCollectorOnlyModel = (model: IModel): boolean => {
 };
 
 export const getCollectorAttrs = (model: IModel): string[] => {
-  if (isCollectorOnlyModel(model)) {
-    return Object.keys(model.columns[0].devices[0].collectorVariables[0]);
-  }
-  return [];
+  return Object.keys(model.columns?.[0].devices?.[0].collectorVariables[0] ?? []);
 };

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -1,0 +1,3 @@
+import { IModel } from "../types";
+
+export const getModelAttrs = (model: IModel): string[] => model.columns.map(column => column.name);


### PR DESCRIPTION
- When the user switches from Mixer or Spinner to the Collector, if there are no data values belonging to the output attribute, the output attribute is deleted, replaced by the set of attributes belonging to the source dataset (from which cases will be collected). If there is no source dataset, then the output attribute is not deleted because otherwise there would be no attribute at the items level.

- When the user switches from the Collector to the Mixer or Spinner, if there are no data values belonging to the source dataset attributes, these attributes are deleted. The attribute(s) associated with the Mixer or Spinner device(s) are added at the items level.

- Note that attributes that have data values are not automatically deleted during these transitions. It's up to the user to decide to delete them either by pressing Clear Data or by manually deleting them in the case table.