### PR TITLE
fix: Keep history of wedge changes [SAMPLER-27]

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -343,6 +343,8 @@ export interface IGetNewPcts {
   selectedVar: string;
   variables: IVariables;
   updateNext?: boolean;
+  fixedVariables: IVariables;
+  setFixedVariables: React.Dispatch<React.SetStateAction<IVariables>>;
 }
 
 export type AvailableDeviceVariables = Record<Id, IVariables>;


### PR DESCRIPTION
This adds a history of wedge changes so that values are distributed over the untouched wedges.