### PR TITLE
fix: Fix model header and arrow layout when scrolling  [SAMPLER-34]

### DIFF
--- a/src/components/App.scss
+++ b/src/components/App.scss
@@ -8,6 +8,7 @@
   bottom: 0;
   right: 0;
   left: 0;
+  overflow: auto;
 
   button {
     &:hover:not(:disabled):not(.disabled) {
@@ -34,16 +35,6 @@
   &:before{
     z-index: 1;
   }
-  &:after {
-    content: "";
-    border-bottom: solid 1px #777;
-    min-width: 100%;
-    width: var(--after-width, auto);
-    z-index: 1;
-    bottom: 0;
-    left: 0;
-    position: absolute;
-  }
 
   .tab {
     display: flex;
@@ -55,6 +46,7 @@
     border-top: solid 1px #777;
     border-left: solid 1px #777;
     border-right: solid 1px #777;
+    border-bottom: solid 1px #777;
     width: fit-content;
     cursor: pointer;
     z-index: 0;
@@ -69,7 +61,7 @@
       background-color: #fff;
       color: #444;
       top: -1px;
-      height: 18px;
+      height: 17px;
       border-bottom: none;
       z-index: 2;
     }

--- a/src/components/about/about.scss
+++ b/src/components/about/about.scss
@@ -2,6 +2,8 @@
   text-align: left;
   padding: 10px 20px;
   font-size: 12px;
+  border-top: solid 1px #777;
+
 
   .funding {
     img {

--- a/src/components/measures/measures.scss
+++ b/src/components/measures/measures.scss
@@ -1,13 +1,15 @@
 .measures-tab {
-  padding: 20px;
   text-align: left;
   font-size: 1rem;
 
   #measures-instructions {
+    padding: 20px 20px 0 20px;
+    border-top: solid 1px #777;
     margin-bottom: 30px;
   }
 
   #select-measure-container, #measure-name-container, #define-measure-container {
+    padding: 0 20px;
     display: flex;
     align-items: center;
     margin-top: 10px;
@@ -134,6 +136,7 @@
   #measures-bottom {
     display: flex;
     justify-content: flex-end;
+    padding-right: 20px;
   }
   label {
     margin-right: 5px;

--- a/src/components/model/arrow.tsx
+++ b/src/components/model/arrow.tsx
@@ -26,12 +26,11 @@ const kWidthBetweenDevices = 40;
 const getRect = (el: HTMLElement): Rect => {
   const {width, height} = el.getBoundingClientRect();
 
-  // correct for the scrolling iframe
   let x = 0;
   let y = 0;
   while (el && !isNaN(el.offsetLeft) && !isNaN(el.offsetTop)) {
-    x += el.offsetLeft - el.scrollLeft;
-    y += el.offsetTop - el.scrollTop;
+    x += el.offsetLeft;
+    y += el.offsetTop;
     el = el.offsetParent as HTMLElement;
   }
   const midY = y + (height / 2);

--- a/src/components/model/model-component.scss
+++ b/src/components/model/model-component.scss
@@ -6,7 +6,8 @@ $pluginMinWidth: 304px;
 }
 
 .model-header {
-  min-width: $pluginMinWidth;
+  border-top: solid 1px #777;
+  min-width: max(100%, var(--device-outputs-width, 0px));
 }
 .model-controls {
   background-color: rgba(0, 140, 186, 0.3);
@@ -312,6 +313,7 @@ $pluginMinWidth: 304px;
   margin: 0 10px 0 20px;
   gap: 40px;
   position: absolute;
+  width: auto;
 
   .device-column {
     position: relative;
@@ -321,7 +323,6 @@ $pluginMinWidth: 304px;
     align-items: center;
 
     &.centered {
-      justify-content: center;
       display: flex;
       flex-direction: column;
     }

--- a/src/components/model/model-component.tsx
+++ b/src/components/model/model-component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useGlobalStateContext } from "../../hooks/useGlobalState";
 import { AnimationContext, useAnimationContextValue } from "../../hooks/useAnimation";
 import { useResizer } from "../../hooks/use-resizer";
@@ -22,7 +22,19 @@ export const ModelTab = () => {
     } else {
       setIsWide(false);
     }
+
   });
+
+  // keep the header the same width as the device outputs
+  useEffect(() => {
+    const deviceOutputs = document.querySelector('.device-outputs-container') as HTMLDivElement;
+    const modelContainer = document.querySelector('.model-header') as HTMLDivElement;
+
+    if (deviceOutputs && modelContainer) {
+      // +20 for the output on the right side
+      modelContainer.style.setProperty('--device-outputs-width', `${deviceOutputs.offsetWidth + 20}px`);
+    }
+  }, [model]);
 
   const handleOpenHelp = () => {
     setShowHelp(!showHelp);


### PR DESCRIPTION
Because the device container is absolute and can grow in width and the header is relative JavaScript must be used to keep their widths in sync.