### PR TITLE
fix: Rename built-in experiment columns when using collectors [SAMPLER-49]

### DIFF
--- a/src/components/model/device.tsx
+++ b/src/components/model/device.tsx
@@ -13,10 +13,10 @@ import { calculateWedgePercentage } from "./device-views/shared/helpers";
 import { SetVariableSeriesModal } from "./variable-setting-modal";
 import DeleteIcon from "../../assets/delete-icon.svg";
 import { parseSpecifier } from "../../utils/utils";
-import { IDevice, IDataContext, ClippingDef, ViewType, IItems, IItem, IVariables } from "../../types";
+import { IDevice, IDataContext, ClippingDef, ViewType, IItem, IVariables } from "../../types";
 import { removeDeviceFromFormulas } from "../../helpers/model-helpers";
 import { DeviceVisibility } from "./device-visibility";
-import { getCollectorAttrs } from "../../utils/collector";
+import { getCollectorAttrs, getCollectorItemValues } from "../../utils/collector";
 import { deleteItemAttrs, getCollectionNames, getItemAttrs } from "../../helpers/codap-helpers";
 import { getModelAttrs } from "../../utils/model";
 
@@ -79,8 +79,7 @@ export const Device = (props: IProps) => {
         throw new Error("No attributes found in the first collection of the data context");
       }
 
-      const items = await getAllItems(dataContextName);
-      const itemValues = items.values.map((item: IItem) => item.values);
+      const itemValues = await getCollectorItemValues(dataContextName);
 
       setGlobalState(draft => {
         draft.enableRunButton = true;
@@ -213,13 +212,9 @@ export const Device = (props: IProps) => {
 
   useEffect(() => {
     if (collectorContextName) {
-      const fetchItems = async () => {
-        const res = await getAllItems(collectorContextName);
-        return res.values;
-      };
+      const fetchItems = async () => await getCollectorItemValues(collectorContextName);
 
-      fetchItems().then((items: IItems) => {
-        const itemValues = items.map((item: IItem) => item.values);
+      fetchItems().then((itemValues) => {
         setGlobalState(draft => {
           const deviceToUpdate = draft.model.columns[columnIndex].devices.find(dev => dev.id === selectedDeviceId);
           if (deviceToUpdate) {

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -7,7 +7,7 @@ import { getDeviceById } from "../models/model-model";
 import { formatFormula, parseFormula } from "../utils/utils";
 import { computeExperimentHash, modelHasSpinner } from "../helpers/model-helpers";
 import { getVariables } from "../utils/formula-parser";
-import { getCollectorAttrs, getCollectorFirstNameVariables, isCollectorOnlyModel } from "../utils/collector";
+import { getCollectorAttrs, getCollectorFirstNameVariables, isCollectorOnlyModel, maybeRenameCollectorItem } from "../utils/collector";
 import { evaluatePattern, isPattern } from "../utils/pattern";
 import { getModelAttrs } from "../utils/model";
 
@@ -152,7 +152,7 @@ export const useAnimationContextValue = (): IAnimationContext => {
 
       if (columnName) {
         if (isCollector) {
-          const newOutputs = currentDevice.collectorVariables[selectedIndex];
+          const newOutputs = maybeRenameCollectorItem(currentDevice.collectorVariables[selectedIndex]);
           outputs = {...newOutputs};
           previousOutputs = {...newOutputs};
         } else {

--- a/src/hooks/useGlobalState.tsx
+++ b/src/hooks/useGlobalState.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect } from "react";
 import { useImmer } from "use-immer";
-import { AttrMap, IColumn, IGlobalState, IGlobalStateContext, ITPSamplerPluginState, Speed, ViewType } from "../types";
+import { IColumn, IGlobalState, IGlobalStateContext, ITPSamplerPluginState, Speed, ViewType } from "../types";
 import { addDataContextChangeListener, codapInterface, IInitializePlugin, initializePlugin } from "@concord-consortium/codap-plugin-api";
 import { createDefaultDevice, createDevice } from "../models/device-model";
 import { kInitialDimensions, kPluginName, kVersion } from "../constants";
@@ -8,15 +8,7 @@ import { createId } from "../utils/id";
 import { removeMissingDevicesFromFormulas } from "../helpers/model-helpers";
 import { ensureMinimumDimensions } from "../helpers/codap-helpers";
 import { isCollectorOnlyModel } from "../utils/collector";
-
-const defaultAttrMap: AttrMap = {
-  experiment: {codapID: null, name: "experiment"},
-  description: {codapID: null, name: "description"},
-  sample_size: {codapID: null, name: "sample size"},
-  until_formula: {codapID: null, name: "formula for until"},
-  experimentHash: {codapID: null, name: "experimentHash"},
-  sample: {codapID: null, name: "sample"},
-};
+import { defaultAttrMap } from "../utils/attr-map";
 
 export const getDefaultState = (): IGlobalState => {
   return {

--- a/src/utils/attr-map.ts
+++ b/src/utils/attr-map.ts
@@ -1,0 +1,10 @@
+import type { AttrMap } from "../types";
+
+export const defaultAttrMap: AttrMap = {
+  experiment: {codapID: null, name: "experiment"},
+  description: {codapID: null, name: "description"},
+  sample_size: {codapID: null, name: "sample size"},
+  until_formula: {codapID: null, name: "formula for until"},
+  experimentHash: {codapID: null, name: "experimentHash"},
+  sample: {codapID: null, name: "sample"},
+};

--- a/src/utils/collector.test.ts
+++ b/src/utils/collector.test.ts
@@ -1,0 +1,86 @@
+import { getDefaultAttrCounts, renameBuiltInVariables, maybeRenameCollectorItem } from "./collector";
+
+describe("collector utils", () => {
+
+  describe("getDefaultAttrCounts", () => {
+    it("should return default attribute counts", () => {
+      const attrCount = getDefaultAttrCounts();
+      expect(attrCount).toEqual({
+        description: 1,
+        experiment: 1,
+        experimentHash: 1,
+        sample: 1,
+        sample_size: 1,
+        until_formula: 1,
+      });
+    });
+  });
+
+  describe("renameBuiltInVariables", () => {
+    it("should rename built-in variables correctly", () => {
+      const attrs = ["description", "experiment", "experimentHash", "sample", "sample_size", "until_formula"];
+      const renamedAttrs = renameBuiltInVariables(attrs);
+      expect(renamedAttrs).toEqual(["description2", "experiment2", "experimentHash2", "sample2", "sample_size2", "until_formula2"]);
+    });
+
+    it("should not rename non-built-in variables", () => {
+      const attrs = ["x", "y", "z"];
+      const renamedAttrs = renameBuiltInVariables(attrs);
+      expect(renamedAttrs).toEqual(attrs);
+    });
+
+    it("should handle mixed variables correctly", () => {
+      const attrs = ["description", "x", "experiment", "y", "sample_size"];
+      const renamedAttrs = renameBuiltInVariables(attrs);
+      expect(renamedAttrs).toEqual(["description2", "x", "experiment2", "y", "sample_size2"]);
+    });
+
+    it("should handle empty array", () => {
+      const attrs: string[] = [];
+      const renamedAttrs = renameBuiltInVariables(attrs);
+      expect(renamedAttrs).toEqual([]);
+    });
+  });
+
+  describe("maybeRenameCollectorItem", () => {
+    it("should rename collector item attributes correctly", () => {
+      const collectorItem = {
+        description: "test",
+        experiment: "exp1",
+        sample_size: 10,
+        until_formula: "a > b",
+      };
+      const renamedItem = maybeRenameCollectorItem(collectorItem);
+      expect(renamedItem).toEqual({
+        description2: "test",
+        experiment2: "exp1",
+        sample_size2: 10,
+        until_formula2: "a > b",
+      });
+    });
+
+    it("should not rename non-built-in attributes", () => {
+      const collectorItem = {
+        customAttr: "customValue",
+      };
+      const renamedItem = maybeRenameCollectorItem(collectorItem);
+      expect(renamedItem).toEqual(collectorItem);
+    });
+
+    it("should rename mixed attributes correctly", () => {
+      const collectorItem = {
+        description: "test",
+        customAttr: "customValue",
+        sample_size: 10,
+        until_formula: "a > b",
+      };
+      const renamedItem = maybeRenameCollectorItem(collectorItem);
+      expect(renamedItem).toEqual({
+        description2: "test",
+        customAttr: "customValue",
+        sample_size2: 10,
+        until_formula2: "a > b",
+      });
+    });
+  });
+});

--- a/src/utils/collector.test.ts
+++ b/src/utils/collector.test.ts
@@ -1,26 +1,19 @@
-import { getDefaultAttrCounts, renameBuiltInVariables, maybeRenameCollectorItem } from "./collector";
+import { renameBuiltInVariables, maybeRenameCollectorItem } from "./collector";
 
 describe("collector utils", () => {
-
-  describe("getDefaultAttrCounts", () => {
-    it("should return default attribute counts", () => {
-      const attrCount = getDefaultAttrCounts();
-      expect(attrCount).toEqual({
-        description: 1,
-        experiment: 1,
-        experimentHash: 1,
-        sample: 1,
-        sample_size: 1,
-        until_formula: 1,
-      });
-    });
-  });
 
   describe("renameBuiltInVariables", () => {
     it("should rename built-in variables correctly", () => {
       const attrs = ["description", "experiment", "experimentHash", "sample", "sample_size", "until_formula"];
       const renamedAttrs = renameBuiltInVariables(attrs);
       expect(renamedAttrs).toEqual(["description2", "experiment2", "experimentHash2", "sample2", "sample_size2", "until_formula2"]);
+    });
+
+    it("should rename variants of built-in variables correctly", () => {
+      const attrs = ["sample", "sample2", "sample3", "sample", "sample3", "sample4", "sample4"];
+      const renamedAttrs = renameBuiltInVariables(attrs);
+      // NOTE: sample22, sample32, sample42 and sample43 is what CODAP does instead of finding the next available number
+      expect(renamedAttrs).toEqual(["sample2", "sample22", "sample3", "sample4", "sample32", "sample42", "sample43"]);
     });
 
     it("should not rename non-built-in variables", () => {
@@ -30,9 +23,9 @@ describe("collector utils", () => {
     });
 
     it("should handle mixed variables correctly", () => {
-      const attrs = ["description", "x", "experiment", "y", "sample_size"];
+      const attrs = ["description", "x", "experiment", "experiment2", "y", "sample_size"];
       const renamedAttrs = renameBuiltInVariables(attrs);
-      expect(renamedAttrs).toEqual(["description2", "x", "experiment2", "y", "sample_size2"]);
+      expect(renamedAttrs).toEqual(["description2", "x", "experiment2", "experiment22", "y", "sample_size2"]);
     });
 
     it("should handle empty array", () => {

--- a/src/utils/collector.ts
+++ b/src/utils/collector.ts
@@ -1,4 +1,6 @@
-import { ViewType, type ICollectorVariables, type IModel } from "../types";
+import { getAllItems } from "@concord-consortium/codap-plugin-api";
+import { ICollectorItem, IItem, ViewType, type ICollectorVariables, type IModel } from "../types";
+import { defaultAttrMap } from "./attr-map";
 
 export const getCollectorFirstNameVariables = (collectorVariables: ICollectorVariables): string[] => {
   if (collectorVariables.length) {
@@ -19,6 +21,49 @@ export const isCollectorOnlyModel = (model: IModel): boolean => {
   return model.columns.length === 1 && model.columns[0].devices.length === 1 && model.columns[0].devices[0].viewType === ViewType.Collector;
 };
 
+export const getDefaultAttrCounts = (): Record<string, number> => {
+  const attrCount: Record<string, number> = {};
+  Object.keys(defaultAttrMap).forEach((attr) => {
+    attrCount[attr] = 1;
+  });
+  return attrCount;
+};
+
+export const renameBuiltInVariables = (attrs: string[]): string[] => {
+  const attrCount = getDefaultAttrCounts();
+
+  return attrs.map((attr) => {
+    if (attrCount[attr] > 0) {
+      attrCount[attr]++;
+      return `${attr}${attrCount[attr]}`;
+    }
+    return attr;
+  });
+};
+
+export const maybeRenameCollectorItem = (collectorItem: ICollectorItem): ICollectorItem => {
+  const attrCount = getDefaultAttrCounts();
+  const renamedItem: ICollectorItem = {};
+  Object.keys(collectorItem).forEach((key) => {
+    if (attrCount[key] > 0) {
+      attrCount[key]++;
+      const newKey = `${key}${attrCount[key]}`;
+      renamedItem[newKey] = collectorItem[key];
+    } else {
+      renamedItem[key] = collectorItem[key];
+    }
+  });
+  return renamedItem;
+};
+
 export const getCollectorAttrs = (model: IModel): string[] => {
-  return Object.keys(model.columns?.[0].devices?.[0].collectorVariables[0] ?? []);
+  const collectorAttrs = Object.keys(model.columns?.[0].devices?.[0].collectorVariables[0] ?? []);
+  const renamedAttrs = renameBuiltInVariables(collectorAttrs);
+  return renamedAttrs;
+};
+
+export const getCollectorItemValues = async (dataContextName: string): Promise<any> => {
+  const items = await getAllItems(dataContextName);
+  const itemValues = items.values.map((item: IItem) => item.values);
+  return itemValues;
 };

--- a/src/utils/collector.ts
+++ b/src/utils/collector.ts
@@ -30,11 +30,13 @@ const maybeRenameAttr = (attr: string, renameSet: Set<string>): string => {
   }
 
   let suffix = 2;
-  while (renameSet.has(`${attr}${suffix}`)) {
-    suffix++;
-  }
-  renameSet.add(`${attr}${suffix}`);
-  return `${attr}${suffix}`;
+  let renamedAttr: string;
+  do {
+    renamedAttr = `${attr}${suffix++}`;
+  } while (renameSet.has(renamedAttr));
+
+  renameSet.add(renamedAttr);
+  return renamedAttr;
 };
 
 export const renameBuiltInVariables = (attrs: string[]): string[] => {


### PR DESCRIPTION
This fixes a bug encountered when the collector has a column with the same name as one of the built-in experiment columns.

This fix mimics CODAP's rename UI where it appends a number, starting at 2 until a new column is found.