### PR TITLE
fix: Change "Conditional Percentage" to "Percentage" [SAMPLER-75]

### DIFF
--- a/src/components/measures/measures.tsx
+++ b/src/components/measures/measures.tsx
@@ -200,7 +200,7 @@ export const MeasuresTab = () => {
             <option value="sum">Sum</option>
             <option value="mean">Mean</option>
             <option value="median">Median</option>
-            <option value="conditional_percentage">Conditional percentage</option>
+            <option value="conditional_percentage">Percentage</option>
           </select>
         </div>
       </div>


### PR DESCRIPTION
This renames the formula label in the measures tab dropdown from "Conditional Percentage" to "Percentage"