### PR TITLE
feat: Save item labels entry in state [SAMPLER-67]

### DIFF
--- a/src/components/model/device.tsx
+++ b/src/components/model/device.tsx
@@ -302,7 +302,17 @@ export const Device = (props: IProps) => {
     });
   }, [selectedDeviceId, setGlobalState, columnIndex]);
 
+  const handleUpdateItemLabels = useCallback((itemLabels: string) => {
+    setGlobalState(draft => {
+      const deviceToUpdate = draft.model.columns[columnIndex].devices.find(dev => dev.id === selectedDeviceId);
+      if (deviceToUpdate) {
+        deviceToUpdate.itemLabels = itemLabels;
+      }
+    });
+  }, [selectedDeviceId, setGlobalState, columnIndex]);
+
   const handleUpdateVariablesToSeries = (series: string) => {
+    handleUpdateItemLabels(series);
     if (series) {
       const sequence = parseSpecifier(series, "to");
       if (sequence) {
@@ -520,6 +530,7 @@ export const Device = (props: IProps) => {
       }
       {showVariableEditor &&
         <SetVariableSeriesModal
+          defaultValue={device.itemLabels}
           setShowVariableEditor={setShowVariableEditor}
           handleUpdateVariablesToSeries={handleUpdateVariablesToSeries}
         />}

--- a/src/components/model/variable-setting-modal.tsx
+++ b/src/components/model/variable-setting-modal.tsx
@@ -3,12 +3,13 @@ import React, { useState } from "react";
 import "./variable-setting-modal.scss";
 
 interface IProps {
+  defaultValue: string;
   setShowVariableEditor: (show: boolean) => void;
   handleUpdateVariablesToSeries: (series: string) => void;
 }
 
-export const SetVariableSeriesModal = ({setShowVariableEditor, handleUpdateVariablesToSeries}: IProps) => {
-  const [candidateVariable, setCandidateVariable] = useState<string>("");
+export const SetVariableSeriesModal = ({defaultValue, setShowVariableEditor, handleUpdateVariablesToSeries}: IProps) => {
+  const [candidateVariable, setCandidateVariable] = useState<string>(defaultValue);
   const handleCloseModal = () => {
     setShowVariableEditor(false);
   };
@@ -28,14 +29,22 @@ export const SetVariableSeriesModal = ({setShowVariableEditor, handleUpdateVaria
   return (
     <div className="set-variables-modal">
       <div className="modal-header">
-        Set Variable Names
+        Set item labels
       </div>
       <div className="modal-body">
         <label htmlFor="variable_names" className="set-variables-input-label">
         {`Enter a list (e.g. 'cat, cat, dog') or a range (e.g. '1-50', '-5 to 5', '1.0 to 5.0', 'A-Z')`}
         </label>
-        <input id="variable_names" className="set-variables-input" type="text" autoFocus={true} placeholder="a to c"
-          onChange={(e) => handleVariablesChange(e.target.value)} onKeyDown={handleVariablesChangeKeyDown}/>
+        <input
+          id="variable_names"
+          className="set-variables-input"
+          type="text"
+          autoFocus={true}
+          placeholder="a to c"
+          value={candidateVariable}
+          onChange={(e) => handleVariablesChange(e.target.value)}
+          onKeyDown={handleVariablesChangeKeyDown}
+        />
       </div>
       <div className="modal-footer">
         <button className="modal-button" onClick={handleCloseModal}>Cancel</button>

--- a/src/hooks/useGlobalState.tsx
+++ b/src/hooks/useGlobalState.tsx
@@ -62,7 +62,8 @@ export const migrateOrCreateInteractiveState = (interactiveState: any, defaultGl
         viewType,
         variables: oldPluginState.variables ?? defaultGlobalState.model.columns[0].devices[0].variables,
         hidden: oldPluginState.hidden ?? false,
-        lockPassword: oldPluginState.password ?? ""
+        lockPassword: oldPluginState.password ?? "",
+        itemLabels: ""
       })]
     };
 
@@ -95,6 +96,11 @@ export const migrateState = (state: IGlobalState) => {
       }
       if (device.lockPassword === undefined) {
         device.lockPassword = "";
+      }
+
+      // ensure all devices have a itemLabels attribute
+      if (device.itemLabels === undefined) {
+        device.itemLabels = "";
       }
     });
   });

--- a/src/models/device-model.tsx
+++ b/src/models/device-model.tsx
@@ -33,7 +33,7 @@ export function findEquivNum(n: number, lcd: number) {
 
 export const kDefaultVars: IVariables = ["a", "a", "b"];
 export const createDefaultDevice = (viewType: ViewType = ViewType.Mixer): IDevice => {
-  return {id: createId(), viewType, variables: kDefaultVars, collectorVariables: [], formulas: {}, hidden: false, lockPassword: ""};
+  return {id: createId(), viewType, variables: kDefaultVars, collectorVariables: [], formulas: {}, hidden: false, lockPassword: "", itemLabels: ""};
 };
 
 interface ICreateDeviceOptions {
@@ -41,7 +41,8 @@ interface ICreateDeviceOptions {
   variables: IVariables,
   hidden: boolean,
   lockPassword: string
+  itemLabels: string;
 }
-export const createDevice = ({viewType, variables, hidden, lockPassword}: ICreateDeviceOptions): IDevice => {
-  return {id: createId(), viewType, variables, collectorVariables: [], formulas: {}, hidden, lockPassword};
+export const createDevice = ({viewType, variables, hidden, lockPassword, itemLabels}: ICreateDeviceOptions): IDevice => {
+  return {id: createId(), viewType, variables, collectorVariables: [], formulas: {}, hidden, lockPassword, itemLabels};
 };

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -239,6 +239,7 @@ export interface IDevice {
   formulas: Record<string, string>;
   hidden: boolean;
   lockPassword: string;
+  itemLabels: string;
 }
 
 // a map of variables to their percentages


### PR DESCRIPTION
This updates the code to save the string entered in the (renamed) "Set items labels" dialog to saved state so that when the dialog is shown again the previously entered text is shown instead of a blank text input.