### PR TITLE
feat: Improvements to values for Description attribute [SAMPLER-74]

### DIFF
--- a/src/helpers/model-helpers.ts
+++ b/src/helpers/model-helpers.ts
@@ -70,4 +70,23 @@ export const removeMissingDevicesFromFormulas = (model: IModel) => {
   });
 };
 
+export const getExperimentDescription = (model: IModel, replacement: boolean): string => {
+  const numDevices = model.columns.reduce<number>((acc, column) => acc + column.devices.length, 0);
+  if (numDevices > 1) {
+    return "Multiple devices";
+  }
 
+  const firstDevice = model.columns[0].devices[0];
+  if (firstDevice.hidden) {
+    return `Hidden ${firstDevice.viewType}`;
+  }
+
+  const hasSpinner = modelHasSpinner(model);
+  const numItems = hasSpinner
+    ? [...new Set(firstDevice.variables)].length
+    : firstDevice.variables.length;
+  const itemsType = hasSpinner ? "segments" : "items";
+  const deviceStr = firstDevice.viewType.charAt(0).toUpperCase() + firstDevice.viewType.slice(1);
+
+  return `${deviceStr} containing ${numItems} ${itemsType}${replacement && !hasSpinner ? " (with replacement)" : ""}`;
+};

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -5,7 +5,7 @@ import { useGlobalStateContext } from "./useGlobalState";
 import { evaluateResult, findOrCreateDataContext, getNewExperimentInfo } from "../helpers/codap-helpers";
 import { getDeviceById } from "../models/model-model";
 import { formatFormula, parseFormula } from "../utils/utils";
-import { computeExperimentHash, modelHasSpinner } from "../helpers/model-helpers";
+import { computeExperimentHash, getExperimentDescription, modelHasSpinner } from "../helpers/model-helpers";
 import { getVariables } from "../utils/formula-parser";
 import { getCollectorAttrs, getCollectorFirstNameVariables, isCollectorOnlyModel, maybeRenameCollectorItem } from "../utils/collector";
 import { evaluatePattern, isPattern } from "../utils/pattern";
@@ -178,9 +178,7 @@ export const useAnimationContextValue = (): IAnimationContext => {
   const getAllExperimentSamples = async (experimentNum: number, startingSampleNumber: number, experimentHash: string) => {
     const results: IExperimentResults = [];
     const animationResults: IExperimentAnimationResults = [];
-    const firstDevice = model.columns[0].devices[0];
     const endSampleNumber = startingSampleNumber + Number(numSamples);
-    const numItems = firstDevice.variables.length;
     const counts = {
       totalSamples: 0,
       failedSamples: 0
@@ -210,8 +208,7 @@ export const useAnimationContextValue = (): IAnimationContext => {
         const sample: { [key: string]: string | number } = {};
         sample[attrMap.experiment.name] = experimentNum;
         sample[attrMap.sample.name] = sampleIndex;
-        const deviceStr = firstDevice.viewType.charAt(0).toUpperCase() + firstDevice.viewType.slice(1);
-        sample[attrMap.description.name] = `${deviceStr} containing ${numItems} items${replacement ? " (with replacement)" : ""}`;
+        sample[attrMap.description.name] = getExperimentDescription(model, replacement);
         if (repeat) {
           sample[attrMap.until_formula.name] = untilFormula;
         } else {


### PR DESCRIPTION
When the device is a Spinner, instead of reporting the number if "items" (which can often be a large number to approximate fractions), report the number if "segments" in the spinner.

When the model is hidden, the description should just be "Hidden mixer" or "Hidden spinner."

When there are multiple devices the description should just be "Multiple devices."