### PR TITLE
fix: Clear data no longer removes formula attributes [SAMPLER-51]

### DIFF
--- a/src/components/model/model-header.tsx
+++ b/src/components/model/model-header.tsx
@@ -38,7 +38,7 @@ export const ModelHeader = (props: IProps) => {
     const deleteItems = async () => {
       try {
         const isCollector = isCollectorOnlyModel(model);
-        const existingAttrs = await getItemAttrs(dataContextName);
+        const existingAttrs = await getItemAttrs(dataContextName, { excludeFormulas: true});
 
         let newAttrs: string[] = [];
         if (isCollector) {

--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -239,9 +239,27 @@ export const deleteAllItems = async (dataContextName: string) => {
   });
 };
 
-export const getItemAttrs = async (dataContextName: string): Promise<string[]> => {
-  const result = await getAttributeList(dataContextName, getCollectionNames().items);
-  return result.success ? result.values.map((attr: any) => attr.name) : [];
+export const getItemAttrs = async (dataContextName: string, options?: {excludeFormulas?: boolean}): Promise<string[]> => {
+  const itemsCollectionName = getCollectionNames().items;
+  const result = await getAttributeList(dataContextName, itemsCollectionName);
+
+  if (!result.success) {
+    return [];
+  }
+
+  const attrs: string[] = result.values.map((attr: any) => attr.name);
+  if (!options?.excludeFormulas) {
+    return attrs;
+  }
+
+  const attrsToExclude: string[] = [];
+  for (const attr of attrs) {
+    const attrResult = await getAttribute(dataContextName, itemsCollectionName, attr);
+    if (attrResult.success && attrResult.values?.formula) {
+      attrsToExclude.push(attr);
+    }
+  }
+  return attrs.filter((attr: string) => attrsToExclude.includes(attr) === false);
 };
 
 export const deleteItemAttrs = async (dataContextName: string, attrs: string[]) => {


### PR DESCRIPTION
With this fix the clear data button no longer removes any attributes from the right most (items) collection that are formulas.