### PR TITLE
fix: Remove overlapping case table [SAMPLER-77]

### DIFF
--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -89,10 +89,8 @@ const createWideTable = async (dataContextName: string) => {
       type: "caseTable",
       dataContext: dataContextName,
       title: "Sampler Data",
-      dimensions: {
-        width: 1000,
-        height: 200
-      }
+      position: "top",
+      horizontalScrollOffset: 5000,
     }
   }) as unknown as IResult;
 };


### PR DESCRIPTION
This removes the explicit width and height and instead sets the horizontal scroll offset to a large number so that the right most cases are visible when the table is loaded.  This fix was suggested by Bill.