### PR TITLE
fix: Use minimum dimensions on new plugin instances [SAMPLER-86]

### DIFF
--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -408,3 +408,8 @@ export const ensureMinimumDimensions = async (min: Dimensions) => {
 
   await codapInterface.sendRequest({ action: "update", resource: "interactiveFrame", values});
 };
+
+export const setDimensions = async ({width, height}: Dimensions) => {
+  const values = {dimensions: {width, height}};
+  await codapInterface.sendRequest({ action: "update", resource: "interactiveFrame", values});
+};

--- a/src/hooks/useGlobalState.tsx
+++ b/src/hooks/useGlobalState.tsx
@@ -6,7 +6,7 @@ import { createDefaultDevice, createDevice } from "../models/device-model";
 import { kInitialDimensions, kPluginName, kVersion } from "../constants";
 import { createId } from "../utils/id";
 import { removeMissingDevicesFromFormulas } from "../helpers/model-helpers";
-import { ensureMinimumDimensions } from "../helpers/codap-helpers";
+import { ensureMinimumDimensions, setDimensions } from "../helpers/codap-helpers";
 import { isCollectorOnlyModel } from "../utils/collector";
 import { defaultAttrMap } from "../utils/attr-map";
 
@@ -123,8 +123,13 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
       // migrate the existing interactive state or create a new one if it doesn't exist
       const newGlobalState = migrateOrCreateInteractiveState(interactiveState, getDefaultState());
 
-      // ensure that the plugin has the minimum dimensions
-      await ensureMinimumDimensions(kInitialDimensions);
+      if (interactiveState === undefined) {
+        // if this is a new document use the initial dimensions
+        await setDimensions(kInitialDimensions);
+      } else {
+        // otherwise ensure that the plugin in the loaded document has the minimum dimensions
+        await ensureMinimumDimensions(kInitialDimensions);
+      }
 
       // ensure there is a experiment hash on existing documents created before that attribute was added
       if (!newGlobalState.attrMap.experimentHash) {


### PR DESCRIPTION
CODAP v3 sets a wider starting window for plugins.  This fix reduces the plugin to the minimum dimensions on a new plugin load, otherwise it ensures the plugin has the minimum dimensions when loaded from a saved document.

This is a noop in CODAP v2 as its plugin window is automatically sized smaller on initial load.