### PR TITLE
fix: Added drag constraint to repeat until modal [SAMPLER-94]

### DIFF
--- a/src/components/model/repeat-until-modal.tsx
+++ b/src/components/model/repeat-until-modal.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useRef, useState } from "react";
 import { useGlobalStateContext } from "../../hooks/useGlobalState";
 import { RepeatCondition } from "../../types";
 import { isRunButtonEnabled } from "../../helpers/model-helpers";
+import { useDragModal } from "../../hooks/use-drag-modal";
 
 interface IProps {
   setShowRepeatUntil: (value: boolean) => void
@@ -9,8 +10,8 @@ interface IProps {
 
 export const RepeatUntilModal = ({ setShowRepeatUntil }: IProps) => {
   const modalRef = useRef<HTMLDivElement>(null);
-  const headerRef = useRef<HTMLDivElement>(null);
-  const [position, setPosition] = useState({ x: 25, y: 60 });
+  const {style, handleMouseDown, handleTouchStart} = useDragModal({modalRef, startPosition: { x: 25, y: 60 }});
+
   const { globalState, setGlobalState } = useGlobalStateContext();
   const { untilFormula, repeatCondition, repeatNumUniqueValues } = globalState;
   const [expressionOrPattern, setExpressionOrPattern] = useState(untilFormula);
@@ -20,27 +21,6 @@ export const RepeatUntilModal = ({ setShowRepeatUntil }: IProps) => {
   const handleCloseModal = useCallback(() => {
     setShowRepeatUntil(false);
   }, [setShowRepeatUntil]);
-
-  const handleMouseDown = (event: React.MouseEvent) => {
-    event.preventDefault();
-    const startX = event.clientX - position.x;
-    const startY = event.clientY - position.y;
-
-    const handleMouseMove = (moveEvent: MouseEvent) => {
-      setPosition({
-        x: moveEvent.clientX - startX,
-        y: moveEvent.clientY - startY,
-      });
-    };
-
-    const handleMouseUp = () => {
-      document.removeEventListener("mousemove", handleMouseMove);
-      document.removeEventListener("mouseup", handleMouseUp);
-    };
-
-    document.addEventListener("mousemove", handleMouseMove);
-    document.addEventListener("mouseup", handleMouseUp);
-  };
 
   const handleSave = useCallback(() => {
     const newUntilFormula = expressionOrPattern.trim();
@@ -124,12 +104,9 @@ export const RepeatUntilModal = ({ setShowRepeatUntil }: IProps) => {
     <div
       ref={modalRef}
       className="repeat-until-modal"
-      style={{
-        left: position.x,
-        top: position.y,
-      }}
+      style={style}
     >
-      <div ref={headerRef} className="modal-header" onMouseDown={handleMouseDown}>
+      <div className="modal-header" onMouseDown={handleMouseDown} onTouchStart={handleTouchStart}>
         Condition to End Repetition
       </div>
       <div className="modal-body">

--- a/src/components/model/variable-setting-modal.tsx
+++ b/src/components/model/variable-setting-modal.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useRef, useMemo, CSSProperties } from "react";
+import React, { useState, useRef } from "react";
+import { useDragModal } from "../../hooks/use-drag-modal";
 
 import "./variable-setting-modal.scss";
 
@@ -8,8 +9,6 @@ interface IProps {
   handleUpdateVariablesToSeries: (series: string) => void;
 }
 
-type ClientPosition = { clientX: number; clientY: number };
-
 export const SetVariableSeriesModal = ({
   defaultValue,
   setShowVariableEditor,
@@ -17,90 +16,8 @@ export const SetVariableSeriesModal = ({
 }: IProps) => {
   const [candidateVariable, setCandidateVariable] = useState<string>(defaultValue);
 
-  // Drag state
-  const [delta, setDelta] = useState({ x: 0, y: 0 });
-  const [dragged, setDragged] = useState(false);
-  const [position, _setPosition] = useState({ x: 0, y: 0 });
-  const [dragging, setDragging] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
-  const modalBounds = useRef<DOMRect | null>(null);
-  const appBounds = useRef<DOMRect | null>(null);
-
-  const style = useMemo(() => {
-    if (!dragged) {
-      return undefined;
-    }
-
-    const { x, y } = position;
-
-    const maxLeft = (appBounds.current?.width || 0) - (modalBounds.current?.width || 0);
-    const maxTop = (appBounds.current?.height || 0) - (modalBounds.current?.height || 0);
-    const left = Math.min(Math.max(0, x + delta.x), maxLeft);
-    const top = Math.min(Math.max(0, y + delta.y), maxTop);
-
-    return {
-      position: "fixed",
-      left,
-      top,
-      zIndex: 1000,
-      cursor: dragging ? "grabbing" : "default",
-      touchAction: "none",
-    } as CSSProperties;
-  }, [dragged, position, delta, dragging]);
-
-  const setPosition = ({clientX, clientY}: ClientPosition) => {
-    _setPosition(() => ({x: clientX, y: clientY}));
-  };
-
-  const startDrag = ({clientX, clientY}: ClientPosition) => {
-    setDragged(true);
-    setDragging(true);
-
-    modalBounds.current = modalRef.current?.getBoundingClientRect() || null;
-    appBounds.current = document.querySelector(".App")?.getBoundingClientRect() || null;
-
-    setDelta({
-      x: (modalRef.current?.getBoundingClientRect().left || 0) - clientX,
-      y: (modalRef.current?.getBoundingClientRect().top || 0) - clientY,
-    });
-    setPosition({ clientX, clientY });
-  };
-
-  // Mouse events
-  const handleMouseDown = (downE: React.MouseEvent<HTMLDivElement>) => {
-    startDrag(downE);
-
-    const handleMouseMove = (moveE: MouseEvent) => {
-      setPosition(moveE);
-    };
-
-    const handleMouseUp = () => {
-      setDragging(false);
-      document.removeEventListener("mousemove", handleMouseMove);
-      document.removeEventListener("mouseup", handleMouseUp);
-    };
-
-    document.addEventListener("mousemove", handleMouseMove);
-    document.addEventListener("mouseup", handleMouseUp);
-  };
-
-  // Touch events
-  const handleTouchStart = (eStart: React.TouchEvent<HTMLDivElement>) => {
-    startDrag(eStart.touches[0]);
-
-    const handleTouchMove = (eMove: TouchEvent) => {
-      setPosition(eMove.touches[0]);
-    };
-
-    const handleTouchEnd = () => {
-      setDragging(false);
-      document.removeEventListener("touchmove", handleTouchMove);
-      document.removeEventListener("touchend", handleTouchEnd);
-    };
-
-    document.addEventListener("touchmove", handleTouchMove);
-    document.addEventListener("touchend", handleTouchEnd);
-  };
+  const {style, handleMouseDown, handleTouchStart} = useDragModal({modalRef, startPosition: { x: 0, y: 0 }});
 
   const handleCloseModal = () => {
     setShowVariableEditor(false);

--- a/src/hooks/use-drag-modal.ts
+++ b/src/hooks/use-drag-modal.ts
@@ -1,0 +1,99 @@
+import { CSSProperties, useMemo, useRef, useState } from "react";
+
+type ClientPosition = { clientX: number; clientY: number };
+
+interface UseDragModalSettings {
+  modalRef: React.RefObject<HTMLDivElement>
+  startPosition: {x: number; y: number};
+}
+
+export const useDragModal = ({modalRef, startPosition}: UseDragModalSettings) => {
+  const [delta, setDelta] = useState({ x: 0, y: 0 });
+  const [dragged, setDragged] = useState(false);
+  const [position, _setPosition] = useState(startPosition);
+  const [dragging, setDragging] = useState(false);
+  const modalBounds = useRef<DOMRect | null>(null);
+  const appBounds = useRef<DOMRect | null>(null);
+
+  const style = useMemo(() => {
+    if (!dragged) {
+      return undefined;
+    }
+
+    const { x, y } = position;
+
+    const maxLeft = (appBounds.current?.width || 0) - (modalBounds.current?.width || 0);
+    const maxTop = (appBounds.current?.height || 0) - (modalBounds.current?.height || 0);
+    const left = Math.min(Math.max(0, x + delta.x), maxLeft);
+    const top = Math.min(Math.max(0, y + delta.y), maxTop);
+
+    return {
+      position: "fixed",
+      left,
+      top,
+      zIndex: 1000,
+      cursor: dragging ? "grabbing" : "default",
+      touchAction: "none",
+    } as CSSProperties;
+  }, [dragged, position, delta, dragging]);
+
+  const setPosition = ({clientX, clientY}: ClientPosition) => {
+    _setPosition(() => ({x: clientX, y: clientY}));
+  };
+
+  const startDrag = ({clientX, clientY}: ClientPosition) => {
+    setDragged(true);
+    setDragging(true);
+
+    modalBounds.current = modalRef.current?.getBoundingClientRect() || null;
+    appBounds.current = document.querySelector(".App")?.getBoundingClientRect() || null;
+
+    setDelta({
+      x: (modalRef.current?.getBoundingClientRect().left || 0) - clientX,
+      y: (modalRef.current?.getBoundingClientRect().top || 0) - clientY,
+    });
+    setPosition({ clientX, clientY });
+  };
+
+  // Mouse events
+  const handleMouseDown = (downE: React.MouseEvent<HTMLDivElement>) => {
+    startDrag(downE);
+
+    const handleMouseMove = (moveE: MouseEvent) => {
+      setPosition(moveE);
+    };
+
+    const handleMouseUp = () => {
+      setDragging(false);
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+  };
+
+  // Touch events
+  const handleTouchStart = (eStart: React.TouchEvent<HTMLDivElement>) => {
+    startDrag(eStart.touches[0]);
+
+    const handleTouchMove = (eMove: TouchEvent) => {
+      setPosition(eMove.touches[0]);
+    };
+
+    const handleTouchEnd = () => {
+      setDragging(false);
+      document.removeEventListener("touchmove", handleTouchMove);
+      document.removeEventListener("touchend", handleTouchEnd);
+    };
+
+    document.addEventListener("touchmove", handleTouchMove);
+    document.addEventListener("touchend", handleTouchEnd);
+  };
+
+  return {
+    style,
+    handleMouseDown,
+    handleTouchStart,
+  };
+};


### PR DESCRIPTION
This moves the drag constraint code from the variable setting modal to a hook which is then used in both the variable setting and repeat until modals.

With this change touch support is also added to the repeat until modal drag handling.