### PR TITLE
fix: Remove img tag from custom select

### DIFF
--- a/src/components/common/custom-select.scss
+++ b/src/components/common/custom-select.scss
@@ -24,7 +24,7 @@
       display: flex;
       align-items: center;
       white-space: nowrap;
-      padding-right: 5px;
+      padding-right: 21px;
       color: #000;
 
       .no-icon {

--- a/src/components/common/custom-select.tsx
+++ b/src/components/common/custom-select.tsx
@@ -111,12 +111,6 @@ export const CustomSelect: React.FC<CustomSelectProps> = ({
           {selected?.icon && <span className="icon">{selected.icon}</span>}
           <span className={selected?.icon ? "" : "no-icon"}>{selected ? selected.label : placeholder}</span>
         </div>
-        <img
-          src="/assets/dropdown-arrow-icon.svg"
-          alt=""
-          className="dropdown-arrow"
-          aria-hidden="true"
-        />
       </div>
 
       {open && !disabled && (


### PR DESCRIPTION
This removes the unneeded dropdown-arrow-icon.svg image tag from the custom select as it is already added in the css using an &::after rule.  Before this change there was a 404 message showing as the img src could not be resolved.  Padding has been added to take the place of the (broken) image.