### PR TITLE
feat: Allow measures without samples [SAMPLER-79]

### DIFF
--- a/src/components/measures/measures.scss
+++ b/src/components/measures/measures.scss
@@ -103,40 +103,18 @@
         }
       }
     }
-    // .formula-dropdown {
-    //   position: relative;
-    //   width: 160px;
-    //   height: 22px;
-    //   margin: 0 5px 0 0;
-    //   display: flex;
-    //   flex-direction: row;
-    //   align-items: center;
-
-    //   select {
-    //     appearance: none;
-    //     -webkit-appearance: none;
-    //     width: 100%;
-    //     height: 100%;
-    //     padding: 1px 8px 1px 8px;
-    //     border-radius: 1.5px;
-    //     border: solid 1px #008cba;
-    //     background-color: #dbf6ff;
-    //     font-size: 11px;
-    //     cursor: pointer;
-    //   }
-    //   &::after {
-    //     content: url("../../assets/dropdown-arrow-icon.svg");
-    //     position: absolute;
-    //     right: 0;
-    //     pointer-events: none;
-    //   }
-    // }
   }
 
   #measures-bottom {
     display: flex;
     justify-content: flex-end;
     padding-right: 20px;
+  }
+  #measures-message {
+    display: flex;
+    justify-content: flex-end;
+    padding: 10px 20px 0 0;
+    font-style: italic;
   }
   label {
     margin-right: 5px;

--- a/src/components/measures/measures.tsx
+++ b/src/components/measures/measures.tsx
@@ -6,6 +6,30 @@ import { getCollectorAttrNames, getCollectorFirstNameVariables, isCollectorOnlyM
 import "./measures.scss";
 
 type Measure = "default" | "conditional_count" | "sum" | "mean" | "median" | "conditional_percentage" | "count_items";
+type MeasureOption = {
+  value: Measure;
+  label: string;
+};
+
+const measureLabels: Record<Measure, string> = {
+  default: "Select a formula",
+  conditional_count: "Count",
+  sum: "Sum",
+  mean: "Mean",
+  median: "Median",
+  conditional_percentage: "Percentage",
+  count_items: "Count items"
+};
+
+const measureOptions: MeasureOption[] = [
+  { value: "default", label: measureLabels.default },
+  { value: "conditional_count", label: measureLabels.conditional_count },
+  { value: "sum", label: measureLabels.sum },
+  { value: "mean", label: measureLabels.mean },
+  { value: "median", label: measureLabels.median },
+  { value: "conditional_percentage", label: measureLabels.conditional_percentage },
+  { value: "count_items", label: measureLabels.count_items }
+];
 
 const getFormula = (measure: Measure, left: string, op: string, right: string) => {
   switch (measure) {
@@ -33,6 +57,7 @@ export const MeasuresTab = () => {
   const [opValue, setOpValue] = useState("=");
   const [rValue, setRValue] = useState("");
   const [hasSamples, setHasSamples] = useState(false);
+  const [message, setMessage] = useState("");
 
   useEffect(() => {
     const checkForSamples = async () => {
@@ -81,6 +106,15 @@ export const MeasuresTab = () => {
   const handleAddMeasure = () => {
     const formula = getFormula(selectedMeasure, lValue, opValue, rValue);
     addMeasure(dataContextName, measureName, selectedMeasure, formula);
+    setMessage(`${measureLabels[selectedMeasure]} measure added.`);
+    setSelectedMeasure("default");
+    setMeasureName("");
+    setLValue("");
+    setOpValue("=");
+    setRValue("");
+    setTimeout(() => {
+      setMessage("");
+    }, 2000);
   };
 
   const renderAttributes = () => {
@@ -197,13 +231,11 @@ export const MeasuresTab = () => {
         </label>
         <div className="select-measure-dropdown">
           <select id="select-measure" onChange={handleSelectMeasureChange} value={selectedMeasure}>
-            <option value="default">Select a formula</option>
-            <option value="conditional_count">Count</option>
-            <option value="sum">Sum</option>
-            <option value="mean">Mean</option>
-            <option value="median">Median</option>
-            <option value="conditional_percentage">Percentage</option>
-            <option value="count_items">Count items</option>
+            {measureOptions.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
           </select>
         </div>
       </div>
@@ -228,6 +260,10 @@ export const MeasuresTab = () => {
         <button id="add-measure" onClick={handleAddMeasure} disabled={disableAddButton} className={disableAddButton ? "disabled" : ""}>
           Add Measure
         </button>
+      </div>
+
+      <div id="measures-message">
+        {message}
       </div>
     </div>
   );

--- a/src/components/model/model-header.tsx
+++ b/src/components/model/model-header.tsx
@@ -73,7 +73,7 @@ export const ModelHeader = (props: IProps) => {
         const attrsToDelete = existingAttrs.filter(attr => !newAttrs.includes(attr));
 
         await deleteAllItems(dataContextName);
-        await findOrCreateDataContext(dataContextName, newAttrs, attrMap, setGlobalState, repeat, isCollector, globalState.instance);
+        await findOrCreateDataContext(dataContextName, newAttrs, attrMap, setGlobalState, repeat, isCollector, globalState.instance, false);
         await deleteItemAttrs(dataContextName, attrsToDelete);
 
       } catch (e) {

--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -103,7 +103,7 @@ export const hasSamplesCollection = async (dataContextName: string): Promise<boo
   return !!collections.find(c => c.name === collectionNames.samples);
 };
 
-export const findOrCreateDataContext = async (initialDataContextName: string, attrs: Array<string>, attrMap: AttrMap, setGlobalState: Updater<IGlobalState>, repeat: boolean, isCollector: boolean, instance: number): Promise<string|null> => {
+export const findOrCreateDataContext = async (initialDataContextName: string, attrs: Array<string>, attrMap: AttrMap, setGlobalState: Updater<IGlobalState>, repeat: boolean, isCollector: boolean, instance: number, createTable: boolean): Promise<string|null> => {
   const collectionNames = getCollectionNames();
 
   // if the plugin is being loaded from a CODAP document, the initialDataContextName will be provided
@@ -186,6 +186,11 @@ export const findOrCreateDataContext = async (initialDataContextName: string, at
     }
 
     await updateAttributeIds(finalDataContextName, attrs, attrMap, setGlobalState);
+
+    if (createTable) {
+      await createWideTable(finalDataContextName, instance);
+    }
+
     return finalDataContextName;
   } else {
     const createRes = await createDataContext(finalDataContextName);
@@ -210,11 +215,11 @@ export const findOrCreateDataContext = async (initialDataContextName: string, at
           const createOutputCollection =
             await createChildCollection(finalDataContextName, collectionNames.items, collectionNames.samples, itemsAttrs);
           if (createOutputCollection.success) {
-            const tableRes = await createWideTable(finalDataContextName, instance);
-            if (tableRes.success) {
-              await updateAttributeIds(finalDataContextName, attrs, attrMap, setGlobalState);
-              return finalDataContextName;
+            await updateAttributeIds(finalDataContextName, attrs, attrMap, setGlobalState);
+            if (createTable) {
+              await createWideTable(finalDataContextName, instance);
             }
+            return finalDataContextName;
           }
         }
       }

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -430,7 +430,7 @@ export const useAnimationContextValue = (): IAnimationContext => {
     try {
       const isCollector = isCollectorOnlyModel(model);
       const attrNames = isCollector ? getCollectorAttrs(model) : getModelAttrs(model);
-      const finalDataContextName = await findOrCreateDataContext(dataContextName, attrNames, attrMap, setGlobalState, repeat, isCollector, globalState.instance);
+      const finalDataContextName = await findOrCreateDataContext(dataContextName, attrNames, attrMap, setGlobalState, repeat, isCollector, globalState.instance, true);
       if (!finalDataContextName) {
         alert("Unable to setup CODAP table");
         return;


### PR DESCRIPTION
The data context is now created at startup, allowing measures to be defined without requiring samples to be present. The case table is not created until the Start button is pressed.

Since the case table is no longer guaranteed to be visible when measures are defined, the measures component has been updated to show a message indicating that the measure was created and the form is cleared.