### PR TITLE
SAMPLER-107: don't abandon an experiment when a CODAP request outlives its deadline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "use-immer": "^0.9.0"
       },
       "devDependencies": {
-        "@concord-consortium/codap-plugin-api": "^0.1.5",
+        "@concord-consortium/codap-plugin-api": "^0.2.0",
         "@cypress/code-coverage": "^3.10.6",
         "@cypress/webpack-preprocessor": "^5.17.1",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
@@ -1950,12 +1950,12 @@
       }
     },
     "node_modules/@concord-consortium/codap-plugin-api": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/codap-plugin-api/-/codap-plugin-api-0.1.6.tgz",
-      "integrity": "sha512-EiOltKLS9Hs3eyQZqSUStroKBr4Maps+3fO12A25ok2gcijrZkioIqlTDSzxVRy1t3ZhLwV2mHMEN1Ts/bNcXg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/codap-plugin-api/-/codap-plugin-api-0.2.0.tgz",
+      "integrity": "sha512-EPHYN38k+gYNcv0+lFL9YQycukFtlecrAmgHB+2kOU/arjbitrCfdD23spL3yIUD6nKoSTmlrCTA6HjqB/b35g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fork-ts-checker-webpack-plugin": "^9.0.2",
         "iframe-phone": "^1.3.1"
       }
     },
@@ -9277,169 +9277,6 @@
         "node": "*"
       }
     },
-    "node_modules/fork-ts-checker-webpack-plugin": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-9.0.2.tgz",
-      "integrity": "sha512-Uochze2R8peoN1XqlSi/rGUkDQpRogtLFocP9+PGu68zk1BDAKXfdeCdyVZpgTk8V8WFVQXdEz426VKjXLO1Gg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cosmiconfig": "^8.2.0",
-        "deepmerge": "^4.2.2",
-        "fs-extra": "^10.0.0",
-        "memfs": "^3.4.1",
-        "minimatch": "^3.0.4",
-        "node-abort-controller": "^3.0.1",
-        "schema-utils": "^3.1.1",
-        "semver": "^7.3.5",
-        "tapable": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=12.13.0",
-        "yarn": ">=1.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">3.6.0",
-        "webpack": "^5.11.0"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
@@ -14142,12 +13979,6 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/node-abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
-      "dev": true
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -20207,12 +20038,11 @@
       "optional": true
     },
     "@concord-consortium/codap-plugin-api": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/codap-plugin-api/-/codap-plugin-api-0.1.6.tgz",
-      "integrity": "sha512-EiOltKLS9Hs3eyQZqSUStroKBr4Maps+3fO12A25ok2gcijrZkioIqlTDSzxVRy1t3ZhLwV2mHMEN1Ts/bNcXg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/codap-plugin-api/-/codap-plugin-api-0.2.0.tgz",
+      "integrity": "sha512-EPHYN38k+gYNcv0+lFL9YQycukFtlecrAmgHB+2kOU/arjbitrCfdD23spL3yIUD6nKoSTmlrCTA6HjqB/b35g==",
       "dev": true,
       "requires": {
-        "fork-ts-checker-webpack-plugin": "^9.0.2",
         "iframe-phone": "^1.3.1"
       }
     },
@@ -25732,123 +25562,6 @@
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true
     },
-    "fork-ts-checker-webpack-plugin": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-9.0.2.tgz",
-      "integrity": "sha512-Uochze2R8peoN1XqlSi/rGUkDQpRogtLFocP9+PGu68zk1BDAKXfdeCdyVZpgTk8V8WFVQXdEz426VKjXLO1Gg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.16.7",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cosmiconfig": "^8.2.0",
-        "deepmerge": "^4.2.2",
-        "fs-extra": "^10.0.0",
-        "memfs": "^3.4.1",
-        "minimatch": "^3.0.4",
-        "node-abort-controller": "^3.0.1",
-        "schema-utils": "^3.1.1",
-        "semver": "^7.3.5",
-        "tapable": "^2.2.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "schema-utils": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-          "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.8",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
-        },
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
-        }
-      }
-    },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
@@ -29315,12 +29028,6 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
-    },
-    "node-abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
-      "dev": true
     },
     "node-forge": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "report-dir": "coverage-cypress"
   },
   "devDependencies": {
-    "@concord-consortium/codap-plugin-api": "^0.1.5",
+    "@concord-consortium/codap-plugin-api": "^0.2.0",
     "@cypress/code-coverage": "^3.10.6",
     "@cypress/webpack-preprocessor": "^5.17.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",

--- a/src/components/measures/measures.tsx
+++ b/src/components/measures/measures.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { tr } from "../../utils/localeManager";
 import { useGlobalStateContext } from "../../hooks/useGlobalState";
 import { addMeasure, hasSamplesCollection } from "../../helpers/codap-helpers";
@@ -59,6 +59,9 @@ export const MeasuresTab = () => {
   const [rValue, setRValue] = useState("");
   const [hasSamples, setHasSamples] = useState(false);
   const [message, setMessage] = useState("");
+  const [addingMeasure, setAddingMeasure] = useState(false);
+  // the timer that clears a success message, held so that a later message is not cleared by it
+  const clearMessageTimerRef = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(() => {
     const checkForSamples = async () => {
@@ -68,10 +71,16 @@ export const MeasuresTab = () => {
     checkForSamples();
   }, [dataContextName]);
 
+  useEffect(() => () => clearTimeout(clearMessageTimerRef.current), []);
+
   const isCollector = useMemo(() => isCollectorOnlyModel(model), [model]);
 
   const disableAddButton = useMemo(() => {
-    let disable = selectedMeasure === "default" || (lValue.length === 0 && selectedMeasure !== "count_items");  // measureName is optional
+    // adding takes up to three requests to CODAP, and a second click while they are in flight
+    // would compute the same name from the same attribute list, which CODAP refuses as a
+    // duplicate -- reporting a failure for a measure that was in fact added
+    let disable = addingMeasure ||
+      selectedMeasure === "default" || (lValue.length === 0 && selectedMeasure !== "count_items");  // measureName is optional
     if (!disable) {
       switch (selectedMeasure) {
         case "conditional_count":
@@ -81,7 +90,7 @@ export const MeasuresTab = () => {
       }
     }
     return disable;
-  }, [selectedMeasure, lValue, rValue]);
+  }, [addingMeasure, selectedMeasure, lValue, rValue]);
 
   const uniqueVariables = useMemo(() => {
     const set = new Set<string>();
@@ -105,9 +114,14 @@ export const MeasuresTab = () => {
   const handleChangeRValue = (e: React.ChangeEvent<HTMLSelectElement>) => setRValue(e.target.value);
 
   const handleAddMeasure = async () => {
+    // the timer from an earlier success would otherwise clear whatever this attempt has to say
+    clearTimeout(clearMessageTimerRef.current);
     setMessage("");
+    setAddingMeasure(true);
+
     const formula = getFormula(selectedMeasure, lValue, opValue, rValue);
     const added = await addMeasure(dataContextName, measureName, selectedMeasure, formula);
+    setAddingMeasure(false);
 
     // A measure that never reached the table has to say so, and the form keeps what the user
     // entered so they can try again without describing the measure a second time. The message
@@ -123,7 +137,7 @@ export const MeasuresTab = () => {
     setLValue("");
     setOpValue("=");
     setRValue("");
-    setTimeout(() => {
+    clearMessageTimerRef.current = setTimeout(() => {
       setMessage("");
     }, 2000);
   };
@@ -274,7 +288,7 @@ export const MeasuresTab = () => {
         </button>
       </div>
 
-      <div id="measures-message">
+      <div id="measures-message" role="status" aria-live="polite">
         {message}
       </div>
     </div>

--- a/src/components/measures/measures.tsx
+++ b/src/components/measures/measures.tsx
@@ -136,6 +136,13 @@ export const MeasuresTab = () => {
     // A measure that never reached the table has to say so, and the form keeps what the user
     // entered so they can try again without describing the measure a second time. The message
     // stays until the next attempt rather than timing out, since there is nothing else to notice.
+    //
+    // TODO: localise this message and the one below it. tr() displays the raw string id when a key
+    // is missing, so the entries have to exist before the keys are used here -- otherwise
+    // DG.Plugin.Sampler.measures.add-failed appears on screen in place of the sentence. The
+    // Sampler's strings live in the CODAP POEditor project, so adding them there is the immediate
+    // route; moving them into a project of their own would be the better one, and would take
+    // plugin strings off the CODAP build and string-synchronization cycle.
     if (!added) {
       setMessage(`Could not add the ${measureLabels[selectedMeasure]} measure. Please try again.`);
       return;

--- a/src/components/measures/measures.tsx
+++ b/src/components/measures/measures.tsx
@@ -104,9 +104,19 @@ export const MeasuresTab = () => {
   const handleChangeOpValue = (e: React.ChangeEvent<HTMLSelectElement>) => setOpValue(e.target.value);
   const handleChangeRValue = (e: React.ChangeEvent<HTMLSelectElement>) => setRValue(e.target.value);
 
-  const handleAddMeasure = () => {
+  const handleAddMeasure = async () => {
+    setMessage("");
     const formula = getFormula(selectedMeasure, lValue, opValue, rValue);
-    addMeasure(dataContextName, measureName, selectedMeasure, formula);
+    const added = await addMeasure(dataContextName, measureName, selectedMeasure, formula);
+
+    // A measure that never reached the table has to say so, and the form keeps what the user
+    // entered so they can try again without describing the measure a second time. The message
+    // stays until the next attempt rather than timing out, since there is nothing else to notice.
+    if (!added) {
+      setMessage(`Could not add the ${measureLabels[selectedMeasure]} measure. Please try again.`);
+      return;
+    }
+
     setMessage(`${measureLabels[selectedMeasure]} measure added.`);
     setSelectedMeasure("default");
     setMeasureName("");

--- a/src/components/measures/measures.tsx
+++ b/src/components/measures/measures.tsx
@@ -75,22 +75,27 @@ export const MeasuresTab = () => {
 
   const isCollector = useMemo(() => isCollectorOnlyModel(model), [model]);
 
-  const disableAddButton = useMemo(() => {
-    // adding takes up to three requests to CODAP, and a second click while they are in flight
-    // would compute the same name from the same attribute list, which CODAP refuses as a
-    // duplicate -- reporting a failure for a measure that was in fact added
-    let disable = addingMeasure ||
+  // An incomplete form genuinely disables the button: there is nothing to add. Being mid-add is
+  // different — it is transient, and taking the button out of the tab order while it holds focus
+  // drops a keyboard or screen reader user to the top of the document for the length of up to
+  // three requests without putting them back. That is the one path this state exists to serve,
+  // where they have to notice a failure and try again, so it is expressed with aria-disabled and
+  // refused in the handler instead.
+  const formIncomplete = useMemo(() => {
+    let incomplete =
       selectedMeasure === "default" || (lValue.length === 0 && selectedMeasure !== "count_items");  // measureName is optional
-    if (!disable) {
+    if (!incomplete) {
       switch (selectedMeasure) {
         case "conditional_count":
         case "conditional_percentage":
-          disable = rValue.length === 0;
+          incomplete = rValue.length === 0;
           break;
       }
     }
-    return disable;
-  }, [addingMeasure, selectedMeasure, lValue, rValue]);
+    return incomplete;
+  }, [selectedMeasure, lValue, rValue]);
+
+  const addUnavailable = formIncomplete || addingMeasure;
 
   const uniqueVariables = useMemo(() => {
     const set = new Set<string>();
@@ -114,6 +119,11 @@ export const MeasuresTab = () => {
   const handleChangeRValue = (e: React.ChangeEvent<HTMLSelectElement>) => setRValue(e.target.value);
 
   const handleAddMeasure = async () => {
+    // adding takes up to three requests to CODAP, and a second activation while they are in flight
+    // would compute the same name from the same attribute list, which CODAP refuses as a duplicate
+    // -- reporting a failure for a measure that was in fact added
+    if (addUnavailable) { return; }
+
     // the timer from an earlier success would otherwise clear whatever this attempt has to say
     clearTimeout(clearMessageTimerRef.current);
     setMessage("");
@@ -283,7 +293,9 @@ export const MeasuresTab = () => {
       </div>
 
       <div id="measures-bottom">
-        <button id="add-measure" onClick={handleAddMeasure} disabled={disableAddButton} className={disableAddButton ? "disabled" : ""}>
+        <button id="add-measure" onClick={handleAddMeasure} disabled={formIncomplete}
+                aria-disabled={addUnavailable} aria-busy={addingMeasure}
+                className={addUnavailable ? "disabled" : ""}>
           {tr("DG.Plugin.Sampler.measures.add-measure")}
         </button>
       </div>

--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -100,7 +100,7 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
                     draft2.attrMap[id].codapID = result.values.attrs[0].id;
                   });
                 }
-              });
+              }).catch(error => console.warn("Sampler: could not create the attribute", error));
           }
         }
       }

--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -100,6 +100,10 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
                     draft2.attrMap[id].codapID = result.values.attrs[0].id;
                   });
                 }
+              // TODO: tell the user. Adding a column is an explicit action, and a create that fails
+              // leaves the column in the model with a null codapID and no attribute behind it, with
+              // nothing on screen to say so. Reporting it means reaching outside the immer recipe
+              // this runs inside, which is why it is a console warning for now.
               }).catch(error => console.warn("Sampler: could not create the attribute", error));
           }
         }

--- a/src/components/model/device.tsx
+++ b/src/components/model/device.tsx
@@ -164,10 +164,16 @@ export const Device = (props: IProps) => {
       });
       const attrsToDelete = maybeAttrsToDelete.filter(attr => !attrsToKeep.has(attr));
 
-      // awaited together: a forEach would drop these promises, leaving a failure with nothing
-      // attached to it and the attribute silently missing
-      await Promise.all(attrsToAdd.map(attr =>
-        createNewAttribute(globalState.dataContextName, getCollectionNames().items, attr)));
+      // awaited together, and reported one at a time: a forEach would drop these promises,
+      // leaving a failure with nothing attached to it, and a create that fails should cost no
+      // more than its own attribute -- the deletes below still need doing
+      await Promise.all(attrsToAdd.map(async (attr) => {
+        try {
+          await createNewAttribute(globalState.dataContextName, getCollectionNames().items, attr);
+        } catch (error) {
+          console.warn("Sampler: could not add the item attribute", attr, error);
+        }
+      }));
       await deleteItemAttrs(globalState.dataContextName, attrsToDelete);
     };
     maybeUpdate().catch(error => console.warn("Sampler: could not update item attributes", error));

--- a/src/components/model/device.tsx
+++ b/src/components/model/device.tsx
@@ -169,7 +169,7 @@ export const Device = (props: IProps) => {
       });
       await deleteItemAttrs(globalState.dataContextName, attrsToDelete);
     };
-    maybeUpdate();
+    maybeUpdate().catch(error => console.warn("Sampler: could not update item attributes", error));
   }, [attrMap, globalState.dataContextName, maybeUpdateItemAttrsSignal, model, repeat, setGlobalState, viewType]);
 
   const maybeUpdateCollectorDataContext = useCallback(() => {
@@ -190,7 +190,7 @@ export const Device = (props: IProps) => {
       if (autoSelectedDataContext) {
         changeDataContext(autoSelectedDataContext.name);
       }
-    });
+    }).catch(error => console.warn("Sampler: could not list data contexts", error));
   }, [changeDataContext, globalState.collectorContextName, globalState.dataContextName]);
 
   useEffect(() => {
@@ -223,7 +223,7 @@ export const Device = (props: IProps) => {
             deviceToUpdate.collectorVariables = itemValues;
           }
         });
-      });
+      }).catch(error => console.warn("Sampler: could not read the collector's items", error));
     }
   }, [collectorContextName, selectedDeviceId, setGlobalState, columnIndex]);
 

--- a/src/components/model/device.tsx
+++ b/src/components/model/device.tsx
@@ -164,9 +164,10 @@ export const Device = (props: IProps) => {
       });
       const attrsToDelete = maybeAttrsToDelete.filter(attr => !attrsToKeep.has(attr));
 
-      attrsToAdd.forEach(async (attr) => {
-        await createNewAttribute(globalState.dataContextName, getCollectionNames().items, attr);
-      });
+      // awaited together: a forEach would drop these promises, leaving a failure with nothing
+      // attached to it and the attribute silently missing
+      await Promise.all(attrsToAdd.map(attr =>
+        createNewAttribute(globalState.dataContextName, getCollectionNames().items, attr)));
       await deleteItemAttrs(globalState.dataContextName, attrsToDelete);
     };
     maybeUpdate().catch(error => console.warn("Sampler: could not update item attributes", error));

--- a/src/components/model/device.tsx
+++ b/src/components/model/device.tsx
@@ -7,7 +7,7 @@ import { NameLabelInput } from "./name-label-input";
 import { PctLabelInput } from "./percent-label-input";
 import { DeviceFooter } from "./device-footer";
 import { kMixerContainerHeight, kMixerContainerWidth, kSpinnerContainerHeight, kSpinnerContainerWidth, kSpinnerX, kSpinnerY } from "./device-views/shared/constants";
-import { codapInterface, createNewAttribute, getAllItems, getDataContext, getListOfDataContexts } from "@concord-consortium/codap-plugin-api";
+import { codapInterface, getAllItems, getDataContext, getListOfDataContexts } from "@concord-consortium/codap-plugin-api";
 import { createNewVarArray, getNextVariable, getPercentOfVar } from "../helpers";
 import { calculateWedgePercentage } from "./device-views/shared/helpers";
 import { SetVariableSeriesModal } from "./variable-setting-modal";
@@ -18,7 +18,7 @@ import { removeDeviceFromFormulas } from "../../helpers/model-helpers";
 import { DeviceVisibility } from "./device-visibility";
 import { DeviceReplacement } from "./device-replacement";
 import { getCollectorAttrs, getCollectorItemValues } from "../../utils/collector";
-import { deleteItemAttrs, getCollectionNames, getItemAttrs } from "../../helpers/codap-helpers";
+import { createItemAttributes, deleteItemAttrs, getItemAttrs } from "../../helpers/codap-helpers";
 import { getModelAttrs } from "../../utils/model";
 
 import "./device.scss";
@@ -164,16 +164,8 @@ export const Device = (props: IProps) => {
       });
       const attrsToDelete = maybeAttrsToDelete.filter(attr => !attrsToKeep.has(attr));
 
-      // awaited together, and reported one at a time: a forEach would drop these promises,
-      // leaving a failure with nothing attached to it, and a create that fails should cost no
-      // more than its own attribute -- the deletes below still need doing
-      await Promise.all(attrsToAdd.map(async (attr) => {
-        try {
-          await createNewAttribute(globalState.dataContextName, getCollectionNames().items, attr);
-        } catch (error) {
-          console.warn("Sampler: could not add the item attribute", attr, error);
-        }
-      }));
+      // the deletes below still need doing, so a create that fails costs no more than its attribute
+      await createItemAttributes(globalState.dataContextName, attrsToAdd, "could not add the item attribute");
       await deleteItemAttrs(globalState.dataContextName, attrsToDelete);
     };
     maybeUpdate().catch(error => console.warn("Sampler: could not update item attributes", error));

--- a/src/components/model/model-header.test.tsx
+++ b/src/components/model/model-header.test.tsx
@@ -15,11 +15,14 @@ jest.mock("../../hooks/useGlobalState", () => ({
   useGlobalStateContext: () => ({ globalState: state, setGlobalState: jest.fn() })
 }));
 
+let runIsUninterruptible = false;
+
 jest.mock("../../hooks/useAnimation", () => ({
   useAnimationContext: () => ({
     handleStartRun: jest.fn(),
     handleTogglePauseRun: jest.fn(),
-    handleStopRun: jest.fn()
+    handleStopRun: jest.fn(),
+    isRunUninterruptible: () => runIsUninterruptible
   })
 }));
 
@@ -51,6 +54,10 @@ function renderHeader() {
 }
 
 describe("ModelHeader start/pause control", () => {
+  beforeEach(() => {
+    runIsUninterruptible = false;
+  });
+
   it("is enabled before a run when the model is runnable", () => {
     setState({ isRunning: false, enableRunButton: true });
     expect(renderHeader().startToggle.disabled).toBe(false);
@@ -65,6 +72,14 @@ describe("ModelHeader start/pause control", () => {
   // act on; leaving it enabled would relabel the control to Start while the run continued.
   it("is disabled while running at the fastest speed", () => {
     setState({ isRunning: true, speed: Speed.Fastest });
+    expect(renderHeader().startToggle.disabled).toBe(true);
+  });
+
+  // Slowing down part-way through the fastest pass does not bring the run back within reach of
+  // pause: the pass ignores the speed once it has started, so the control must stay disabled.
+  it("stays disabled when the speed is lowered during an uninterruptible run", () => {
+    runIsUninterruptible = true;
+    setState({ isRunning: true, speed: Speed.Slow });
     expect(renderHeader().startToggle.disabled).toBe(true);
   });
 

--- a/src/components/model/model-header.test.tsx
+++ b/src/components/model/model-header.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ModelHeader } from "./model-header";
+import { Speed } from "../../types";
+
+// Identity translation so the controls can be located by their (stable) tooltip keys; the
+// start/pause toggle's accessible name changes with run state, its tooltip key does not.
+jest.mock("../../utils/localeManager", () => ({
+  tr: (key: string) => key
+}));
+
+let state: any;
+
+jest.mock("../../hooks/useGlobalState", () => ({
+  useGlobalStateContext: () => ({ globalState: state, setGlobalState: jest.fn() })
+}));
+
+jest.mock("../../hooks/useAnimation", () => ({
+  useAnimationContext: () => ({
+    handleStartRun: jest.fn(),
+    handleTogglePauseRun: jest.fn(),
+    handleStopRun: jest.fn()
+  })
+}));
+
+function setState(overrides: Record<string, any> = {}) {
+  state = {
+    repeat: false,
+    sampleSize: "5",
+    numSamples: "100",
+    enableRunButton: true,
+    isRunning: false,
+    isPaused: false,
+    model: { columns: [{ id: "c1", name: "Deck1", devices: [{ id: "d1", viewType: "mixer", variables: ["a"], replacement: true, formulas: {} }] }] },
+    dataContextName: "Sampler",
+    untilFormula: "",
+    attrMap: {},
+    repeatCondition: "",
+    repeatNumUniqueValues: 1,
+    speed: Speed.Slow,
+    ...overrides
+  };
+}
+
+function renderHeader() {
+  render(<ModelHeader showRepeatUntil={false} isWide={false} setShowRepeatUntil={jest.fn()} />);
+  return {
+    startToggle: screen.getByTitle(/tooltip\.(start|pause)-sampling/) as HTMLButtonElement,
+    stopButton: screen.getByTitle("DG.Plugin.Sampler.tooltip.stop-sampling") as HTMLButtonElement
+  };
+}
+
+describe("ModelHeader start/pause control", () => {
+  it("is enabled before a run when the model is runnable", () => {
+    setState({ isRunning: false, enableRunButton: true });
+    expect(renderHeader().startToggle.disabled).toBe(false);
+  });
+
+  it("is enabled while running at a speed that animates", () => {
+    setState({ isRunning: true, speed: Speed.Slow });
+    expect(renderHeader().startToggle.disabled).toBe(false);
+  });
+
+  // At the fastest speed the run completes in one uninterruptible pass, so pause has nothing to
+  // act on; leaving it enabled would relabel the control to Start while the run continued.
+  it("is disabled while running at the fastest speed", () => {
+    setState({ isRunning: true, speed: Speed.Fastest });
+    expect(renderHeader().startToggle.disabled).toBe(true);
+  });
+
+  it("leaves stop enabled while running at the fastest speed", () => {
+    setState({ isRunning: true, speed: Speed.Fastest });
+    expect(renderHeader().stopButton.disabled).toBe(false);
+  });
+
+  it("is enabled again at the fastest speed once the run ends", () => {
+    setState({ isRunning: false, enableRunButton: true, speed: Speed.Fastest });
+    expect(renderHeader().startToggle.disabled).toBe(false);
+  });
+});

--- a/src/components/model/model-header.tsx
+++ b/src/components/model/model-header.tsx
@@ -41,13 +41,14 @@ export const ModelHeader = (props: IProps) => {
   const { globalState, setGlobalState } = useGlobalStateContext();
   const { repeat, sampleSize, numSamples, enableRunButton, isRunning, isPaused, model, dataContextName, untilFormula, attrMap, repeatCondition, repeatNumUniqueValues, speed } = globalState;
   const { handleStartRun, handleTogglePauseRun, handleStopRun, isRunUninterruptible } = useAnimationContext();
-  // At the fastest speed the experiment runs to completion in a single uninterruptible pass, so
-  // there is nothing for pause to act on. Leaving it enabled would relabel the control to Start
-  // while the run carried on regardless. Stop still applies, and remains enabled.
+  // Pause has nothing to act on during the fastest pass, which runs to the end of the experiment
+  // whatever the speed does from here; left enabled it would relabel itself to Start while the run
+  // carried on. Two conditions because they ask about different runs: the speed about one yet to
+  // reach that pass, the latch about one already in it. Stop applies throughout, and stays enabled.
   //
-  // The speed asks about a run that has yet to reach that pass; the run itself is asked about one
-  // already in it, since slowing down from fastest part-way through does not bring it back within
-  // reach of pause.
+  // The latch is a ref, so reading it does not re-render this. It does not have to: the latch only
+  // decides the outcome once the speed has been lowered mid-pass, and that speed change is itself a
+  // state change that re-renders. A latch that could flip without one would need to become state.
   const pauseUnavailable = isRunning && (speed === Speed.Fastest || isRunUninterruptible());
   const startToggleDisabled = (!isRunning && !enableRunButton) || pauseUnavailable;
 

--- a/src/components/model/model-header.tsx
+++ b/src/components/model/model-header.tsx
@@ -40,11 +40,15 @@ export const ModelHeader = (props: IProps) => {
   const { showRepeatUntil, isWide, setShowRepeatUntil } = props;
   const { globalState, setGlobalState } = useGlobalStateContext();
   const { repeat, sampleSize, numSamples, enableRunButton, isRunning, isPaused, model, dataContextName, untilFormula, attrMap, repeatCondition, repeatNumUniqueValues, speed } = globalState;
-  const { handleStartRun, handleTogglePauseRun, handleStopRun } = useAnimationContext();
+  const { handleStartRun, handleTogglePauseRun, handleStopRun, isRunUninterruptible } = useAnimationContext();
   // At the fastest speed the experiment runs to completion in a single uninterruptible pass, so
   // there is nothing for pause to act on. Leaving it enabled would relabel the control to Start
   // while the run carried on regardless. Stop still applies, and remains enabled.
-  const pauseUnavailable = isRunning && speed === Speed.Fastest;
+  //
+  // The speed asks about a run that has yet to reach that pass; the run itself is asked about one
+  // already in it, since slowing down from fastest part-way through does not bring it back within
+  // reach of pause.
+  const pauseUnavailable = isRunning && (speed === Speed.Fastest || isRunUninterruptible());
   const startToggleDisabled = (!isRunning && !enableRunButton) || pauseUnavailable;
 
   const numDevices = useMemo(() => model.columns.reduce<number>((acc, column) => acc + column.devices.length, 0), [model]);

--- a/src/components/model/model-header.tsx
+++ b/src/components/model/model-header.tsx
@@ -11,6 +11,7 @@ import { getModelAttrs } from "../../utils/model";
 import { RepeatUntilModal } from "./repeat-until-modal";
 import { CustomSelect, CustomSelectOption } from "../common/custom-select";
 import { tr } from "../../utils/localeManager";
+import { Speed } from "../../types";
 
 const startLabel = tr("DG.Plugin.Sampler.top-bar.run");
 const startTip = tr("DG.Plugin.Sampler.tooltip.start-sampling");
@@ -38,9 +39,13 @@ interface IProps {
 export const ModelHeader = (props: IProps) => {
   const { showRepeatUntil, isWide, setShowRepeatUntil } = props;
   const { globalState, setGlobalState } = useGlobalStateContext();
-  const { repeat, sampleSize, numSamples, enableRunButton, isRunning, isPaused, model, dataContextName, untilFormula, attrMap, repeatCondition, repeatNumUniqueValues } = globalState;
+  const { repeat, sampleSize, numSamples, enableRunButton, isRunning, isPaused, model, dataContextName, untilFormula, attrMap, repeatCondition, repeatNumUniqueValues, speed } = globalState;
   const { handleStartRun, handleTogglePauseRun, handleStopRun } = useAnimationContext();
-  const startToggleDisabled = !isRunning && !enableRunButton;
+  // At the fastest speed the experiment runs to completion in a single uninterruptible pass, so
+  // there is nothing for pause to act on. Leaving it enabled would relabel the control to Start
+  // while the run carried on regardless. Stop still applies, and remains enabled.
+  const pauseUnavailable = isRunning && speed === Speed.Fastest;
+  const startToggleDisabled = (!isRunning && !enableRunButton) || pauseUnavailable;
 
   const numDevices = useMemo(() => model.columns.reduce<number>((acc, column) => acc + column.devices.length, 0), [model]);
   const multipleDevices = useMemo(() => numDevices > 1, [numDevices]);

--- a/src/helpers/codap-helpers.test.ts
+++ b/src/helpers/codap-helpers.test.ts
@@ -90,12 +90,25 @@ describe("addMeasure", () => {
     expect(secondRequest().values[0].name).toBe("count1");
   });
 
-  // Nothing awaits addMeasure, so a rejection here would have nothing attached to observe it.
+  // The caller tells the user the measure was added, so it has to hear about a measure that was
+  // not: a request CODAP never answers rejects, and one it refuses answers with success false.
+  it("reports success when the measure is created", async () => {
+    mockSendRequest.mockResolvedValueOnce(attributeList([]));
+
+    await expect(addMeasure("ctx", "My Measure", "count", "count()")).resolves.toBe(true);
+  });
+
+  it("reports success when an existing named measure is updated", async () => {
+    mockSendRequest.mockResolvedValueOnce(attributeList(["My Measure"]));
+
+    await expect(addMeasure("ctx", "My Measure", "count", "count()")).resolves.toBe(true);
+  });
+
   it("reports a failed request rather than letting it escape", async () => {
     const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
     mockSendRequest.mockRejectedValue(new Error("CODAP request timed out"));
 
-    await expect(addMeasure("ctx", "My Measure", "count", "count()")).resolves.toBeUndefined();
+    await expect(addMeasure("ctx", "My Measure", "count", "count()")).resolves.toBe(false);
 
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
@@ -107,9 +120,25 @@ describe("addMeasure", () => {
       .mockResolvedValueOnce(attributeList([]))
       .mockRejectedValueOnce(new Error("CODAP request timed out"));
 
-    await expect(addMeasure("ctx", "My Measure", "count", "count()")).resolves.toBeUndefined();
+    await expect(addMeasure("ctx", "My Measure", "count", "count()")).resolves.toBe(false);
 
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
+  });
+
+  it("reports a create CODAP refused", async () => {
+    mockSendRequest
+      .mockResolvedValueOnce(attributeList([]))
+      .mockResolvedValueOnce({ success: false, values: { error: "duplicate attribute name" } });
+
+    await expect(addMeasure("ctx", "My Measure", "count", "count()")).resolves.toBe(false);
+  });
+
+  it("does not create anything when the attribute list cannot be read", async () => {
+    mockSendRequest.mockResolvedValueOnce({ success: false, values: { error: "no such collection" } });
+
+    await expect(addMeasure("ctx", "My Measure", "count", "count()")).resolves.toBe(false);
+
+    expect(mockSendRequest).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/helpers/codap-helpers.test.ts
+++ b/src/helpers/codap-helpers.test.ts
@@ -1,0 +1,115 @@
+import { codapInterface } from "@concord-consortium/codap-plugin-api";
+import { addMeasure } from "./codap-helpers";
+
+jest.mock("@concord-consortium/codap-plugin-api", () => ({
+  ...jest.requireActual("@concord-consortium/codap-plugin-api"),
+  codapInterface: { sendRequest: jest.fn() }
+}));
+
+// Identity translation, so the collection name in a resource string is the key it came from.
+jest.mock("../utils/localeManager", () => ({
+  tr: (key: string) => key
+}));
+
+const mockSendRequest = codapInterface.sendRequest as jest.Mock;
+
+/** What CODAP answers an attributeList request with. */
+const attributeList = (names: string[]) => ({ success: true, values: names.map(name => ({ name })) });
+
+/** The request issued after the attributeList lookup — the create or update under test. */
+const secondRequest = () => mockSendRequest.mock.calls[1][0];
+
+/** Runs addMeasure and lets its requests settle, whatever shape it returns. */
+async function runAddMeasure(...args: Parameters<typeof addMeasure>) {
+  await addMeasure(...args);
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe("addMeasure", () => {
+  beforeEach(() => {
+    mockSendRequest.mockReset();
+    mockSendRequest.mockResolvedValue({ success: true });
+  });
+
+  it("creates an attribute named for the measure when that name is free", async () => {
+    mockSendRequest.mockResolvedValueOnce(attributeList(["something else"]));
+
+    await runAddMeasure("ctx", "My Measure", "count", "count()");
+
+    expect(mockSendRequest).toHaveBeenCalledTimes(2);
+    expect(secondRequest().action).toBe("create");
+    expect(secondRequest().values[0]).toEqual({ name: "My Measure", type: "numeric", formula: "count()" });
+  });
+
+  it("names the attribute for the measure type when no name is given", async () => {
+    mockSendRequest.mockResolvedValueOnce(attributeList([]));
+
+    await runAddMeasure("ctx", "", "count", "count()");
+
+    expect(secondRequest().action).toBe("create");
+    expect(secondRequest().values[0].name).toBe("count");
+  });
+
+  // A named measure reuses its attribute, so adding it again edits the formula in place rather
+  // than accumulating duplicates.
+  it("updates the existing attribute when a named measure is added again", async () => {
+    mockSendRequest.mockResolvedValueOnce(attributeList(["My Measure"]));
+
+    await runAddMeasure("ctx", "My Measure", "count", "count()");
+
+    expect(mockSendRequest).toHaveBeenCalledTimes(2);
+    expect(secondRequest().action).toBe("update");
+    expect(secondRequest().resource).toContain("attribute[My Measure]");
+    expect(secondRequest().values).toEqual({ formula: "count()" });
+  });
+
+  // An unnamed measure can be added repeatedly with different formulas, so each one needs its own
+  // attribute: the type name, then the lowest unused numeric suffix.
+  it("gives an unnamed measure the first suffix when only the base name is taken", async () => {
+    mockSendRequest.mockResolvedValueOnce(attributeList(["count"]));
+
+    await runAddMeasure("ctx", "", "count", "count()");
+
+    expect(secondRequest().action).toBe("create");
+    expect(secondRequest().values[0].name).toBe("count1");
+  });
+
+  it("gives an unnamed measure the next suffix after the highest one taken", async () => {
+    mockSendRequest.mockResolvedValueOnce(attributeList(["count", "count1"]));
+
+    await runAddMeasure("ctx", "", "count", "count()");
+
+    expect(secondRequest().values[0].name).toBe("count2");
+  });
+
+  it("reuses a gap in the suffixes rather than always taking the next one", async () => {
+    mockSendRequest.mockResolvedValueOnce(attributeList(["count", "count2"]));
+
+    await runAddMeasure("ctx", "", "count", "count()");
+
+    expect(secondRequest().values[0].name).toBe("count1");
+  });
+
+  // Nothing awaits addMeasure, so a rejection here would have nothing attached to observe it.
+  it("reports a failed request rather than letting it escape", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    mockSendRequest.mockRejectedValue(new Error("CODAP request timed out"));
+
+    await expect(addMeasure("ctx", "My Measure", "count", "count()")).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("reports a failure from the create rather than letting it escape", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    mockSendRequest
+      .mockResolvedValueOnce(attributeList([]))
+      .mockRejectedValueOnce(new Error("CODAP request timed out"));
+
+    await expect(addMeasure("ctx", "My Measure", "count", "count()")).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/src/helpers/codap-helpers.test.ts
+++ b/src/helpers/codap-helpers.test.ts
@@ -1,9 +1,12 @@
-import { codapInterface } from "@concord-consortium/codap-plugin-api";
-import { addMeasure } from "./codap-helpers";
+import { codapInterface, getAttributeList, getDataContext } from "@concord-consortium/codap-plugin-api";
+import { addMeasure, findOrCreateDataContext } from "./codap-helpers";
 
 jest.mock("@concord-consortium/codap-plugin-api", () => ({
   ...jest.requireActual("@concord-consortium/codap-plugin-api"),
-  codapInterface: { sendRequest: jest.fn() }
+  codapInterface: { sendRequest: jest.fn() },
+  getDataContext: jest.fn(),
+  getAttributeList: jest.fn(),
+  createNewAttribute: jest.fn()
 }));
 
 // Identity translation, so the collection name in a resource string is the key it came from.
@@ -19,12 +22,6 @@ const attributeList = (names: string[]) => ({ success: true, values: names.map(n
 /** The request issued after the attributeList lookup — the create or update under test. */
 const secondRequest = () => mockSendRequest.mock.calls[1][0];
 
-/** Runs addMeasure and lets its requests settle, whatever shape it returns. */
-async function runAddMeasure(...args: Parameters<typeof addMeasure>) {
-  await addMeasure(...args);
-  await new Promise(resolve => setTimeout(resolve, 0));
-}
-
 describe("addMeasure", () => {
   beforeEach(() => {
     mockSendRequest.mockReset();
@@ -34,7 +31,7 @@ describe("addMeasure", () => {
   it("creates an attribute named for the measure when that name is free", async () => {
     mockSendRequest.mockResolvedValueOnce(attributeList(["something else"]));
 
-    await runAddMeasure("ctx", "My Measure", "count", "count()");
+    await addMeasure("ctx", "My Measure", "count", "count()");
 
     expect(mockSendRequest).toHaveBeenCalledTimes(2);
     expect(secondRequest().action).toBe("create");
@@ -44,7 +41,7 @@ describe("addMeasure", () => {
   it("names the attribute for the measure type when no name is given", async () => {
     mockSendRequest.mockResolvedValueOnce(attributeList([]));
 
-    await runAddMeasure("ctx", "", "count", "count()");
+    await addMeasure("ctx", "", "count", "count()");
 
     expect(secondRequest().action).toBe("create");
     expect(secondRequest().values[0].name).toBe("count");
@@ -55,7 +52,7 @@ describe("addMeasure", () => {
   it("updates the existing attribute when a named measure is added again", async () => {
     mockSendRequest.mockResolvedValueOnce(attributeList(["My Measure"]));
 
-    await runAddMeasure("ctx", "My Measure", "count", "count()");
+    await addMeasure("ctx", "My Measure", "count", "count()");
 
     expect(mockSendRequest).toHaveBeenCalledTimes(2);
     expect(secondRequest().action).toBe("update");
@@ -68,7 +65,7 @@ describe("addMeasure", () => {
   it("gives an unnamed measure the first suffix when only the base name is taken", async () => {
     mockSendRequest.mockResolvedValueOnce(attributeList(["count"]));
 
-    await runAddMeasure("ctx", "", "count", "count()");
+    await addMeasure("ctx", "", "count", "count()");
 
     expect(secondRequest().action).toBe("create");
     expect(secondRequest().values[0].name).toBe("count1");
@@ -77,7 +74,7 @@ describe("addMeasure", () => {
   it("gives an unnamed measure the next suffix after the highest one taken", async () => {
     mockSendRequest.mockResolvedValueOnce(attributeList(["count", "count1"]));
 
-    await runAddMeasure("ctx", "", "count", "count()");
+    await addMeasure("ctx", "", "count", "count()");
 
     expect(secondRequest().values[0].name).toBe("count2");
   });
@@ -85,7 +82,7 @@ describe("addMeasure", () => {
   it("reuses a gap in the suffixes rather than always taking the next one", async () => {
     mockSendRequest.mockResolvedValueOnce(attributeList(["count", "count2"]));
 
-    await runAddMeasure("ctx", "", "count", "count()");
+    await addMeasure("ctx", "", "count", "count()");
 
     expect(secondRequest().values[0].name).toBe("count1");
   });
@@ -134,11 +131,112 @@ describe("addMeasure", () => {
     await expect(addMeasure("ctx", "My Measure", "count", "count()")).resolves.toBe(false);
   });
 
+  it("reports an update CODAP refused", async () => {
+    mockSendRequest
+      .mockResolvedValueOnce(attributeList(["My Measure"]))
+      .mockResolvedValueOnce({ success: false, values: { error: "no such attribute" } });
+
+    await expect(addMeasure("ctx", "My Measure", "count", "count()")).resolves.toBe(false);
+  });
+
   it("does not create anything when the attribute list cannot be read", async () => {
     mockSendRequest.mockResolvedValueOnce({ success: false, values: { error: "no such collection" } });
 
     await expect(addMeasure("ctx", "My Measure", "count", "count()")).resolves.toBe(false);
 
     expect(mockSendRequest).toHaveBeenCalledTimes(1);
+  });
+});
+
+const mockGetDataContext = getDataContext as jest.Mock;
+const mockGetAttributeList = getAttributeList as jest.Mock;
+
+/** The attribute ids the run holds before the batched get is answered. */
+const testAttrMap = () => ({
+  experiment: { codapID: null, name: "experiment" },
+  description: { codapID: null, name: "description" },
+  sample_size: { codapID: null, name: "sample size" },
+  until_formula: { codapID: null, name: "formula for until" },
+  experimentHash: { codapID: null, name: "experimentHash" },
+  sample: { codapID: null, name: "sample" }
+});
+
+/**
+ * Runs `findOrCreateDataContext` against an existing data context that already has every attribute,
+ * so the only request left for it to make is the batched get of the attribute ids, and answers that
+ * get with `answer` — the shape under test.
+ */
+async function runAttributeIdLookup(answer: unknown) {
+  const attrMap = testAttrMap();
+  const state = { attrMap } as any;
+  const setGlobalState = jest.fn((recipe: (draft: any) => void) => recipe(state));
+
+  mockGetDataContext.mockResolvedValue({ success: true, values: {} });
+  mockGetAttributeList.mockResolvedValue(
+    attributeList(["experiment", "description", "sample size", "experimentHash", "Deck1"]));
+  mockSendRequest.mockImplementation((request: unknown, callback?: (result: unknown) => void) => {
+    callback?.(answer);
+    return Promise.resolve({ success: true });
+  });
+
+  const name = await findOrCreateDataContext(
+    "Sampler", ["Deck1"], attrMap as any, setGlobalState as any, false, false, 1, false);
+
+  return { name, attrMap: state.attrMap, setGlobalState };
+}
+
+// The ids already held are better than a response that carries none, and a run must not be
+// abandoned over a lookup that only refreshes them.
+describe("findOrCreateDataContext attribute id lookup", () => {
+  beforeEach(() => {
+    mockSendRequest.mockReset();
+    mockGetDataContext.mockReset();
+    mockGetAttributeList.mockReset();
+  });
+
+  it("leaves the ids alone when the request goes unanswered", async () => {
+    const { name, attrMap, setGlobalState } = await runAttributeIdLookup(undefined);
+
+    expect(setGlobalState).not.toHaveBeenCalled();
+    expect(attrMap.experiment.codapID).toBeNull();
+    expect(name).toBe("Sampler");
+  });
+
+  it("leaves the ids alone when the batch is answered with a single error", async () => {
+    const { attrMap, setGlobalState } =
+      await runAttributeIdLookup({ success: false, values: { error: "no such data context" } });
+
+    expect(setGlobalState).not.toHaveBeenCalled();
+    expect(attrMap.experiment.codapID).toBeNull();
+  });
+
+  it("writes only the ids the batch answered for", async () => {
+    const { attrMap } = await runAttributeIdLookup([
+      { success: true, values: { name: "experiment", id: "11" } },
+      { success: false, values: { error: "not found" } },
+      { success: true, values: { name: "sample", id: "22" } }
+    ]);
+
+    expect(attrMap.experiment.codapID).toBe("11");
+    expect(attrMap.sample.codapID).toBe("22");
+    expect(attrMap.description.codapID).toBeNull();
+  });
+
+  // Setting up sends more requests than anything else in a run, so it is the likeliest place for
+  // one to outlive the deadline. The ids are a cache; the run is the point.
+  it("still returns the data context when the lookup fails outright", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const attrMap = testAttrMap();
+    mockGetDataContext.mockResolvedValue({ success: true, values: {} });
+    mockGetAttributeList.mockResolvedValue(
+      attributeList(["experiment", "description", "sample size", "experimentHash", "Deck1"]));
+    mockSendRequest.mockRejectedValue(new Error("CODAP request timed out"));
+
+    const name = await findOrCreateDataContext(
+      "Sampler", ["Deck1"], attrMap as any, jest.fn() as any, false, false, 1, false);
+
+    expect(name).toBe("Sampler");
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -67,7 +67,11 @@ const updateAttributeIds = async (dataContextName: string, attrs: Array<string>,
     "resource": `dataContext[${dataContextName}].collection[${collectionAttr.collection}].attribute[${collectionAttr.attrName}]`
   }));
 
-  await codapInterface.sendRequest(reqs, (getAttrsResult: any[]) => {
+  await codapInterface.sendRequest(reqs, (getAttrsResult?: IResult[]) => {
+    // absent when CODAP didn't answer, in which case the await above throws and the existing ids
+    // are left alone rather than being overwritten from a response we never got
+    if (!getAttrsResult) { return; }
+
     const updatedAttrsIds: Record<keyof AttrMap, string> = {};
     getAttrsResult.forEach((res: {success: boolean, values: Record<string, string>}) => {
       if (res.success) {
@@ -282,66 +286,69 @@ export const deleteItemAttrs = async (dataContextName: string, attrs: string[]) 
   }
 };
 
-export const addMeasure = (dataContextName: string, measureName: string, measureType: string, formula: string) => {
+export const addMeasure = async (dataContextName: string, measureName: string, measureType: string, formula: string) => {
   const samplesColl = getCollectionNames().samples;
 
-  codapInterface.sendRequest({
-    action: "get",
-    resource: `dataContext[${dataContextName}].collection[${samplesColl}].attributeList`
-  }).then((res: any) => {
+  // Each request rejects if CODAP doesn't answer it, and nothing awaits this function, so the
+  // whole sequence is guarded here rather than leaving a rejection with nothing attached to it.
+  try {
+    const res = await codapInterface.sendRequest({
+      action: "get",
+      resource: `dataContext[${dataContextName}].collection[${samplesColl}].attributeList`
+    }) as IResult;
+
     const attrs = res.values;
     let newAttributeName = measureName ? measureName : measureType;
     // check if attr name is already used. user could add "conditional count" twice, for example,
     // but have difference formulas (output = a, output = b)
     const attrNameAlreadyUsed = attrs.find((attr: any) => attr.name === newAttributeName);
 
-      if (!attrNameAlreadyUsed) {
-        codapInterface.sendRequest({
-          action: 'create',
-          resource: `dataContext[${dataContextName}].collection[${samplesColl}].attribute`,
-          values: [{
-            name: newAttributeName,
-            type: "numeric",
-            formula
-          }]
-        });
-      } else if (attrNameAlreadyUsed && !measureName) {
-        const attrsWithSameName = attrs.filter((attr: any) => attr.name.startsWith(newAttributeName));
-        const indexes = attrsWithSameName.map((attr: any) => Number(attr.name.slice(newAttributeName.length)));
-        const highestIndex = Math.max(...indexes);
-        if (!highestIndex) {
-          newAttributeName = newAttributeName + 1;
-        } else {
-          for (let i = 1; i <= highestIndex; i++) {
-            const nameWithIndex = newAttributeName + i;
-            const isNameWithIndexUsed = attrsWithSameName.find((attr: any) => attr.name === nameWithIndex);
-            if (!isNameWithIndexUsed) {
-              newAttributeName = nameWithIndex;
-              break;
-            } else if (i === highestIndex) {
-              newAttributeName = newAttributeName + (highestIndex + 1);
-            }
+    // a named measure reuses its attribute, so the formula is updated in place
+    if (attrNameAlreadyUsed && measureName) {
+      await codapInterface.sendRequest({
+        action: "update",
+        resource: `dataContext[${dataContextName}].collection[${samplesColl}].attribute[${measureName}]`,
+        values: {
+          formula
+        }
+      });
+      return;
+    }
+
+    // an unnamed measure gets the lowest unused numeric suffix
+    if (attrNameAlreadyUsed) {
+      const attrsWithSameName = attrs.filter((attr: any) => attr.name.startsWith(newAttributeName));
+      const indexes = attrsWithSameName.map((attr: any) => Number(attr.name.slice(newAttributeName.length)));
+      const highestIndex = Math.max(...indexes);
+      if (!highestIndex) {
+        newAttributeName = newAttributeName + 1;
+      } else {
+        for (let i = 1; i <= highestIndex; i++) {
+          const nameWithIndex = newAttributeName + i;
+          const isNameWithIndexUsed = attrsWithSameName.find((attr: any) => attr.name === nameWithIndex);
+          if (!isNameWithIndexUsed) {
+            newAttributeName = nameWithIndex;
+            break;
+          } else if (i === highestIndex) {
+            newAttributeName = newAttributeName + (highestIndex + 1);
           }
         }
-        codapInterface.sendRequest({
-          action: 'create',
-          resource: `dataContext[${dataContextName}].collection[${samplesColl}].attribute`,
-          values: [{
-            name: newAttributeName,
-            type: "numeric",
-            formula
-          }]
-        });
-      } else if (attrNameAlreadyUsed && measureName) {
-        codapInterface.sendRequest({
-          action: 'update',
-          resource: `dataContext[${dataContextName}].collection[${samplesColl}].attribute[${measureName}]`,
-          values: {
-            formula
-          }
-        });
       }
+    }
+
+    await codapInterface.sendRequest({
+      action: "create",
+      resource: `dataContext[${dataContextName}].collection[${samplesColl}].attribute`,
+      values: [{
+        name: newAttributeName,
+        type: "numeric",
+        formula
+      }]
     });
+  } catch (error) {
+
+    console.warn("Sampler: could not add the measure", error);
+  }
 };
 
 export const getNewExperimentInfo = async (dataContextName: string, experimentHash: string) => {

--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -49,6 +49,40 @@ export const getCollectionNames = () => {
   };
 };
 
+/**
+ * Issues a CODAP request, reporting rather than propagating a failure.
+ *
+ * A large request can exceed the plugin API's response deadline and reject while CODAP is still
+ * processing it successfully, so a rejection does not mean the work failed — only that we stopped
+ * waiting for it. Since the outcome is unknown either way, work that does not depend on the answer
+ * should carry on rather than being abandoned.
+ *
+ * This is the one spelling of "report, don't propagate" in the plugin; reach for it rather than
+ * writing another `.catch` that logs, so the rule stays in one place.
+ */
+export const tryRequest = async <T,>(
+  request: () => Promise<T>, describe = "CODAP request did not complete"
+): Promise<T | undefined> => {
+  try {
+    return await request();
+  } catch (error) {
+    console.warn(`Sampler: ${describe}`, error);
+    return undefined;
+  }
+};
+
+/**
+ * Creates the named attributes on the items collection.
+ *
+ * Awaited together and reported one at a time: a forEach would drop these promises, leaving a
+ * failure with nothing attached to it, and one attribute that cannot be created should not cost
+ * the rest.
+ */
+export const createItemAttributes = async (dataContextName: string, attrNames: string[], describe: string) => {
+  await Promise.all(attrNames.map(attr =>
+    tryRequest(() => createNewAttribute(dataContextName, getCollectionNames().items, attr), `${describe} ${attr}`)));
+};
+
 const updateAttributeIds = async (dataContextName: string, attrs: Array<string>, attrMap: AttrMap, setGlobalState: Updater<IGlobalState>) => {
   const allAttrs = [
     {collection: "experiments", attrName: attrMap.experiment.name},
@@ -161,13 +195,14 @@ export const findOrCreateDataContext = async (initialDataContextName: string, at
       }
 
       if (createNewAttr) {
-        await createNewAttribute(finalDataContextName, collectionNames.experiments, experimentAttrName);
+        await tryRequest(() => createNewAttribute(finalDataContextName, collectionNames.experiments, experimentAttrName),
+          "could not add the experiment column");
       }
     }
 
     // ensure that the experimentHash column exists (it will not exist in older TPSampler documents)
     if (!attrList.find((attr: {name: string}) => attr.name === attrMap.experimentHash.name)) {
-      await codapInterface.sendRequest({
+      await tryRequest(() => codapInterface.sendRequest({
         action: "create",
         resource: `dataContext[${finalDataContextName}].collection[${collectionNames.experiments}].attribute`,
         values: [
@@ -177,33 +212,27 @@ export const findOrCreateDataContext = async (initialDataContextName: string, at
             hidden: true
           }
         ]
-      });
+      }), "could not add the experiment hash column");
     }
 
-    attrList = (await getAttributeList(finalDataContextName, collectionNames.items)).values;
+    attrList = (await tryRequest(() => getAttributeList(finalDataContextName, collectionNames.items),
+      "could not list the item attributes"))?.values ?? [];
     const attrNames: string[] = attrList.map((attr: {id: number, name: string, title: string}) => attr.name);
 
     // ensure that if a user deleted a CODAP attr representing a device column, it is reinstated
     const missingAttrs = attrs.filter(attr => !attrNames.includes(attr));
     if (missingAttrs.length > 0) {
-      // awaited, and reported one at a time: a forEach would drop these promises, leaving a
-      // failure with nothing attached to it, and one attribute that cannot be reinstated should
-      // not cost the rest of the setup
-      await Promise.all(missingAttrs.map(async (attr) => {
-        try {
-          await createNewAttribute(finalDataContextName, collectionNames.items, attr);
-        } catch (error) {
-          console.warn("Sampler: could not reinstate the item attribute", attr, error);
-        }
-      }));
+      await createItemAttributes(finalDataContextName, missingAttrs, "could not reinstate the item attribute");
     }
 
     // if this is a collector run and there are no existing items remove all non-collector attributes
     if (isCollector) {
-      const itemCountResult = await getCaseCount(finalDataContextName, collectionNames.items);
-      if (itemCountResult.success && itemCountResult.values === 0) {
+      const itemCountResult = await tryRequest(() => getCaseCount(finalDataContextName, collectionNames.items),
+        "could not count the existing items");
+      if (itemCountResult?.success && itemCountResult.values === 0) {
         const nonCollectorAttrs = attrNames.filter(attr => !attrs.includes(attr));
-        deleteItemAttrs(finalDataContextName, nonCollectorAttrs);
+        await tryRequest(() => deleteItemAttrs(finalDataContextName, nonCollectorAttrs),
+          "could not remove the non-collector attributes");
       }
     }
 

--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -67,10 +67,13 @@ const updateAttributeIds = async (dataContextName: string, attrs: Array<string>,
     "resource": `dataContext[${dataContextName}].collection[${collectionAttr.collection}].attribute[${collectionAttr.attrName}]`
   }));
 
-  await codapInterface.sendRequest(reqs, (getAttrsResult?: IResult[]) => {
-    // a batched get is answered with one result per request; anything else — no answer at all, or
-    // a single error for the batch — leaves the existing ids alone rather than overwriting them
-    // from a response that never carried any
+  await codapInterface.sendRequest(reqs, (getAttrsResult?: IResult | IResult[]) => {
+    // A batched get is answered with one result per request. Anything else carries no ids to read:
+    // undefined when the request is given up on, a single result when CODAP answers the batch with
+    // one error. Either way the ids already held are better than nothing.
+    //
+    // Being given up on does not cancel the request, so a late answer calls this a second time —
+    // with the results, which are then applied.
     if (!Array.isArray(getAttrsResult)) { return; }
 
     const updatedAttrsIds: Record<keyof AttrMap, string> = {};
@@ -183,9 +186,16 @@ export const findOrCreateDataContext = async (initialDataContextName: string, at
     // ensure that if a user deleted a CODAP attr representing a device column, it is reinstated
     const missingAttrs = attrs.filter(attr => !attrNames.includes(attr));
     if (missingAttrs.length > 0) {
-      missingAttrs.forEach(async (attr) => {
-        await createNewAttribute(finalDataContextName, collectionNames.items, attr);
-      });
+      // awaited, and reported one at a time: a forEach would drop these promises, leaving a
+      // failure with nothing attached to it, and one attribute that cannot be reinstated should
+      // not cost the rest of the setup
+      await Promise.all(missingAttrs.map(async (attr) => {
+        try {
+          await createNewAttribute(finalDataContextName, collectionNames.items, attr);
+        } catch (error) {
+          console.warn("Sampler: could not reinstate the item attribute", attr, error);
+        }
+      }));
     }
 
     // if this is a collector run and there are no existing items remove all non-collector attributes
@@ -197,10 +207,17 @@ export const findOrCreateDataContext = async (initialDataContextName: string, at
       }
     }
 
-    await updateAttributeIds(finalDataContextName, attrs, attrMap, setGlobalState);
+    // Neither of these is worth the run: updateAttributeIds only refreshes cached attribute ids,
+    // and the table createWideTable opens is already open on a document being run again. Setting
+    // up sends more requests than any other part of a run, so it is the likeliest place for one
+    // to outlive the response deadline, and an experiment must not be abandoned before it starts
+    // over a request that told us nothing we did not already have.
+    await updateAttributeIds(finalDataContextName, attrs, attrMap, setGlobalState)
+      .catch(error => console.warn("Sampler: could not refresh the attribute ids", error));
 
     if (createTable) {
-      await createWideTable(finalDataContextName, instance);
+      await createWideTable(finalDataContextName, instance)
+        .catch(error => console.warn("Sampler: could not open the case table", error));
     }
 
     return finalDataContextName;
@@ -227,9 +244,12 @@ export const findOrCreateDataContext = async (initialDataContextName: string, at
           const createOutputCollection =
             await createChildCollection(finalDataContextName, collectionNames.items, collectionNames.samples, itemsAttrs);
           if (createOutputCollection.success) {
-            await updateAttributeIds(finalDataContextName, attrs, attrMap, setGlobalState);
+            // as above: neither of these is worth abandoning a run over
+            await updateAttributeIds(finalDataContextName, attrs, attrMap, setGlobalState)
+              .catch(error => console.warn("Sampler: could not refresh the attribute ids", error));
             if (createTable) {
-              await createWideTable(finalDataContextName, instance);
+              await createWideTable(finalDataContextName, instance)
+                .catch(error => console.warn("Sampler: could not open the case table", error));
             }
             return finalDataContextName;
           }

--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -68,9 +68,10 @@ const updateAttributeIds = async (dataContextName: string, attrs: Array<string>,
   }));
 
   await codapInterface.sendRequest(reqs, (getAttrsResult?: IResult[]) => {
-    // absent when CODAP didn't answer, in which case the await above throws and the existing ids
-    // are left alone rather than being overwritten from a response we never got
-    if (!getAttrsResult) { return; }
+    // a batched get is answered with one result per request; anything else — no answer at all, or
+    // a single error for the batch — leaves the existing ids alone rather than overwriting them
+    // from a response that never carried any
+    if (!Array.isArray(getAttrsResult)) { return; }
 
     const updatedAttrsIds: Record<keyof AttrMap, string> = {};
     getAttrsResult.forEach((res: {success: boolean, values: Record<string, string>}) => {

--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -287,16 +287,25 @@ export const deleteItemAttrs = async (dataContextName: string, attrs: string[]) 
   }
 };
 
-export const addMeasure = async (dataContextName: string, measureName: string, measureType: string, formula: string) => {
+/**
+ * Adds (or, for a named measure that already exists, updates) a measure attribute.
+ *
+ * Reports whether the measure made it into the table: a request CODAP doesn't answer rejects, and
+ * one it refuses resolves with success false, and neither is something the caller can tell the
+ * user about after the fact.
+ */
+export const addMeasure = async (dataContextName: string, measureName: string, measureType: string, formula: string): Promise<boolean> => {
   const samplesColl = getCollectionNames().samples;
 
-  // Each request rejects if CODAP doesn't answer it, and nothing awaits this function, so the
-  // whole sequence is guarded here rather than leaving a rejection with nothing attached to it.
   try {
     const res = await codapInterface.sendRequest({
       action: "get",
       resource: `dataContext[${dataContextName}].collection[${samplesColl}].attributeList`
     }) as IResult;
+
+    if (!res.success) {
+      return false;
+    }
 
     const attrs = res.values;
     let newAttributeName = measureName ? measureName : measureType;
@@ -306,14 +315,14 @@ export const addMeasure = async (dataContextName: string, measureName: string, m
 
     // a named measure reuses its attribute, so the formula is updated in place
     if (attrNameAlreadyUsed && measureName) {
-      await codapInterface.sendRequest({
+      const updated = await codapInterface.sendRequest({
         action: "update",
         resource: `dataContext[${dataContextName}].collection[${samplesColl}].attribute[${measureName}]`,
         values: {
           formula
         }
-      });
-      return;
+      }) as IResult;
+      return updated.success;
     }
 
     // an unnamed measure gets the lowest unused numeric suffix
@@ -337,7 +346,7 @@ export const addMeasure = async (dataContextName: string, measureName: string, m
       }
     }
 
-    await codapInterface.sendRequest({
+    const created = await codapInterface.sendRequest({
       action: "create",
       resource: `dataContext[${dataContextName}].collection[${samplesColl}].attribute`,
       values: [{
@@ -345,10 +354,11 @@ export const addMeasure = async (dataContextName: string, measureName: string, m
         type: "numeric",
         formula
       }]
-    });
+    }) as IResult;
+    return created.success;
   } catch (error) {
-
     console.warn("Sampler: could not add the measure", error);
+    return false;
   }
 };
 

--- a/src/hooks/useAnimation-run-state.test.tsx
+++ b/src/hooks/useAnimation-run-state.test.tsx
@@ -1,17 +1,21 @@
 import { renderHook } from "@testing-library/react";
+import { createItems } from "@concord-consortium/codap-plugin-api";
 import { findOrCreateDataContext, getNewExperimentInfo } from "../helpers/codap-helpers";
 import { computeExperimentHash } from "../helpers/model-helpers";
 import { useAnimationContextValue } from "./useAnimation";
-import { Speed } from "../types";
+import { AnimationStep, Speed } from "../types";
 
 jest.mock("@concord-consortium/codap-plugin-api", () => ({
-  createItems: jest.fn().mockResolvedValue({ caseIDs: [] }),
-  selectCases: jest.fn().mockResolvedValue({})
+  createItems: jest.fn().mockResolvedValue({ success: true }),
+  selectCases: jest.fn().mockResolvedValue({ success: true }),
+  getCaseCount: jest.fn().mockResolvedValue({ success: true, values: 1 }),
+  getCaseByIndex: jest.fn().mockResolvedValue({ success: true, values: { case: { id: 1 } } })
 }));
 
 jest.mock("../helpers/codap-helpers", () => ({
   findOrCreateDataContext: jest.fn(),
   getNewExperimentInfo: jest.fn(),
+  getCollectionNames: jest.fn(() => ({ experiments: "experiments", samples: "samples", items: "items" })),
   evaluateResult: jest.fn(() => true)
 }));
 
@@ -30,14 +34,28 @@ jest.mock("./useGlobalState", () => ({
   useGlobalStateContext: () => ({ globalState: state, setGlobalState: mockSetGlobalState })
 }));
 
+const mockCreateItems = createItems as jest.Mock;
 const mockFindOrCreateDataContext = findOrCreateDataContext as jest.Mock;
 const mockGetNewExperimentInfo = getNewExperimentInfo as jest.Mock;
 const mockComputeExperimentHash = computeExperimentHash as jest.Mock;
 
+// Lets the pending CODAP requests of an abandoned or animating run settle before asserting on what
+// they did, since the run that issued them is no longer awaited.
+const flushRequests = () => new Promise(resolve => setTimeout(resolve, 0));
+
 function resetState() {
   state = {
     speed: Speed.Fastest,
-    attrMap: {},
+    // The samples are named after these attributes, so an empty map would fail the run before it
+    // ever reached the animation these tests are about.
+    attrMap: {
+      experiment: { codapID: null, name: "Experiment" },
+      description: { codapID: null, name: "Description" },
+      sample_size: { codapID: null, name: "Sample Size" },
+      until_formula: { codapID: null, name: "Until" },
+      experimentHash: { codapID: null, name: "experimentHash" },
+      sample: { codapID: null, name: "Sample" }
+    },
     model: { columns: [{ id: "c1", name: "Deck1", devices: [{ id: "d1", viewType: "mixer", variables: ["a"], replacement: true, formulas: {} }] }] },
     numSamples: "1",
     sampleSize: "1",
@@ -57,8 +75,13 @@ describe("handleStartRun run-state feedback", () => {
   beforeEach(() => {
     resetState();
     mockSetGlobalState.mockClear();
+    mockCreateItems.mockClear();
     mockGetNewExperimentInfo.mockResolvedValue({ experimentNum: 1, startingSampleNumber: 1 });
     mockComputeExperimentHash.mockResolvedValue("hash");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   // Collecting the samples requires many round-trips to CODAP, so the run can be under way for
@@ -80,6 +103,57 @@ describe("handleStartRun run-state feedback", () => {
 
     releaseDataContext("Sampler");
     await run;
+    await flushRequests();
+  });
+
+  // Stopping a run that is still being set up has no animation to cancel, so the run has to
+  // abandon itself rather than start and write an experiment the user asked not to have.
+  it("abandons a run that is stopped while it is being set up", async () => {
+    let releaseDataContext: (value: string) => void = () => undefined;
+    mockFindOrCreateDataContext.mockImplementation(
+      () => new Promise<string>(resolve => { releaseDataContext = resolve; }));
+
+    const { result } = renderHook(() => useAnimationContextValue());
+
+    const run = result.current.handleStartRun();
+    await result.current.handleStopRun();
+
+    releaseDataContext("Sampler");
+    await run;
+    await flushRequests();
+
+    expect(mockCreateItems).not.toHaveBeenCalled();
+    expect(state.isRunning).toBe(false);
+    expect(state.enableRunButton).toBe(true);
+  });
+
+  // Pausing during the setup pauses an animation that is about to be replaced by the one the run
+  // is still building, so the run has to carry the pause over to it.
+  it("starts the animation paused when the run was paused while being set up", async () => {
+    state.speed = Speed.Slow;
+    const frames: FrameRequestCallback[] = [];
+    jest.spyOn(window, "requestAnimationFrame")
+      .mockImplementation(callback => frames.push(callback));
+
+    let releaseDataContext: (value: string) => void = () => undefined;
+    mockFindOrCreateDataContext.mockImplementation(
+      () => new Promise<string>(resolve => { releaseDataContext = resolve; }));
+
+    const { result } = renderHook(() => useAnimationContextValue());
+    const animatedSteps: AnimationStep[] = [];
+    result.current.registerAnimationCallback(step => { animatedSteps.push(step); });
+
+    const run = result.current.handleStartRun();
+    await result.current.handleTogglePauseRun(true);
+
+    releaseDataContext("Sampler");
+    await run;
+
+    expect(frames).not.toHaveLength(0);
+    frames[frames.length - 1](0);
+
+    expect(animatedSteps.map(step => step.kind)).not.toContain("startExperiment");
+    expect(state.isPaused).toBe(true);
   });
 
   it("re-enables the run button when the data context cannot be set up", async () => {

--- a/src/hooks/useAnimation-run-state.test.tsx
+++ b/src/hooks/useAnimation-run-state.test.tsx
@@ -162,6 +162,37 @@ describe("handleStartRun run-state feedback", () => {
     expect(state.enableRunButton).toBe(false);
   });
 
+  // The fastest pass walks the steps of the run it started on. Reading the current runtime each
+  // time round the loop instead would let a superseded run resume into its replacement: it would
+  // advance the replacement's step index — skipping whichever step that landed on, losing the
+  // samples of a pushVariables — and announce an end of experiment over a run still collecting.
+  it("does not step or end the run that replaced a superseded fastest pass", async () => {
+    mockFindOrCreateDataContext.mockResolvedValue("Sampler");
+    let releaseFirstCreate: (value: unknown) => void = () => undefined;
+    mockCreateItems
+      .mockImplementationOnce(() => new Promise(resolve => { releaseFirstCreate = resolve; }))
+      .mockImplementationOnce(() => new Promise(() => undefined));
+
+    const { result } = renderHook(() => useAnimationContextValue());
+
+    await result.current.handleStartRun();
+    await flushRequests();
+
+    await result.current.handleStopRun();
+    await result.current.handleStartRun();
+    await flushRequests();
+
+    // watch the replacement run only, from the point it is under way
+    const steps: AnimationStep["kind"][] = [];
+    const unregister = result.current.registerAnimationCallback(step => steps.push(step.kind));
+
+    releaseFirstCreate({ success: true });
+    await flushRequests();
+    unregister();
+
+    expect(steps).not.toContain("endExperiment");
+  });
+
   // Setting up is several requests long, and the answer to Stop cannot wait for the one still in
   // flight: a run stopped anywhere in there has to abandon itself before it animates.
   it("abandons a run stopped after the data context is set up", async () => {

--- a/src/hooks/useAnimation-run-state.test.tsx
+++ b/src/hooks/useAnimation-run-state.test.tsx
@@ -47,14 +47,16 @@ function resetState() {
   state = {
     speed: Speed.Fastest,
     // The samples are named after these attributes, so an empty map would fail the run before it
-    // ever reached the animation these tests are about.
+    // ever reached the animation these tests are about. The sample attribute carries the
+    // translated name the animation itself looks samples up by, so a run whose rows are to reach
+    // the create has to use it rather than a name of the test's own choosing.
     attrMap: {
-      experiment: { codapID: null, name: "Experiment" },
-      description: { codapID: null, name: "Description" },
-      sample_size: { codapID: null, name: "Sample Size" },
-      until_formula: { codapID: null, name: "Until" },
+      experiment: { codapID: null, name: "experiment" },
+      description: { codapID: null, name: "description" },
+      sample_size: { codapID: null, name: "sample size" },
+      until_formula: { codapID: null, name: "formula for until" },
       experimentHash: { codapID: null, name: "experimentHash" },
-      sample: { codapID: null, name: "Sample" }
+      sample: { codapID: null, name: "sample" }
     },
     model: { columns: [{ id: "c1", name: "Deck1", devices: [{ id: "d1", viewType: "mixer", variables: ["a"], replacement: true, formulas: {} }] }] },
     numSamples: "1",
@@ -125,6 +127,121 @@ describe("handleStartRun run-state feedback", () => {
     expect(mockCreateItems).not.toHaveBeenCalled();
     expect(state.isRunning).toBe(false);
     expect(state.enableRunButton).toBe(true);
+  });
+
+  // The animation steps hold on to the run's end callback, and the request they are waiting on can
+  // settle long after the user gave up on that run. Ending it then would hand the controls back
+  // over the run that took its place.
+  it("does not end the run that replaced one the user stopped", async () => {
+    mockFindOrCreateDataContext.mockResolvedValue("Sampler");
+    let releaseFirstCreate: (value: unknown) => void = () => undefined;
+    mockCreateItems
+      .mockImplementationOnce(() => new Promise(resolve => { releaseFirstCreate = resolve; }))
+      // the replacement run is still writing its own samples when the first run's create lands
+      .mockImplementationOnce(() => new Promise(() => undefined));
+
+    const { result } = renderHook(() => useAnimationContextValue());
+
+    await result.current.handleStartRun();
+    await flushRequests();
+
+    await result.current.handleStopRun();
+    await result.current.handleStartRun();
+    await flushRequests();
+
+    releaseFirstCreate({ success: true });
+    await flushRequests();
+
+    expect(state.isRunning).toBe(true);
+    expect(state.enableRunButton).toBe(false);
+  });
+
+  // Setting up is several requests long, and the answer to Stop cannot wait for the one still in
+  // flight: a run stopped anywhere in there has to abandon itself before it animates.
+  it("abandons a run stopped after the data context is set up", async () => {
+    mockFindOrCreateDataContext.mockResolvedValue("Sampler");
+    let releaseExperimentInfo: (value: unknown) => void = () => undefined;
+    mockGetNewExperimentInfo.mockImplementation(
+      () => new Promise(resolve => { releaseExperimentInfo = resolve; }));
+
+    const { result } = renderHook(() => useAnimationContextValue());
+
+    const run = result.current.handleStartRun();
+    await flushRequests();
+    await result.current.handleStopRun();
+
+    releaseExperimentInfo({ experimentNum: 1, startingSampleNumber: 1 });
+    await run;
+    await flushRequests();
+
+    expect(mockCreateItems).not.toHaveBeenCalled();
+    expect(state.isRunning).toBe(false);
+  });
+
+  // Stopping during the setup has to be answered before the run reports a setup failure of its
+  // own: the user is not waiting on a table for a run they abandoned.
+  it("does not report a setup failure for a run the user stopped", async () => {
+    const alertSpy = jest.spyOn(window, "alert").mockImplementation(() => undefined);
+    let releaseDataContext: (value: string) => void = () => undefined;
+    mockFindOrCreateDataContext.mockImplementation(
+      () => new Promise<string>(resolve => { releaseDataContext = resolve; }));
+
+    const { result } = renderHook(() => useAnimationContextValue());
+
+    const run = result.current.handleStartRun();
+    await result.current.handleStopRun();
+
+    releaseDataContext("");
+    await run;
+
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+
+  // Starting again abandons the run being set up for the same reason stopping does: only one run
+  // can be under way, and it is the one the user asked for last.
+  it("abandons a run superseded by another start", async () => {
+    const releaseDataContexts: Array<(value: string) => void> = [];
+    mockFindOrCreateDataContext.mockImplementation(
+      () => new Promise<string>(resolve => { releaseDataContexts.push(resolve); }));
+
+    const { result } = renderHook(() => useAnimationContextValue());
+
+    const firstRun = result.current.handleStartRun();
+    const secondRun = result.current.handleStartRun();
+
+    releaseDataContexts[0]("Sampler");
+    await firstRun;
+    await flushRequests();
+
+    expect(mockCreateItems).not.toHaveBeenCalled();
+
+    releaseDataContexts[1]("Sampler");
+    await secondRun;
+    await flushRequests();
+
+    expect(mockCreateItems).toHaveBeenCalledTimes(1);
+  });
+
+  // The controls read this to decide whether pause can still act on the run, so it has to follow
+  // the run itself: set when the run enters the pass that finishes it, cleared when the run ends.
+  it("reports a fastest run as uninterruptible until it ends", async () => {
+    mockFindOrCreateDataContext.mockResolvedValue("Sampler");
+    let releaseCreate: (value: unknown) => void = () => undefined;
+    mockCreateItems.mockImplementationOnce(() => new Promise(resolve => { releaseCreate = resolve; }));
+
+    const { result } = renderHook(() => useAnimationContextValue());
+    expect(result.current.isRunUninterruptible()).toBe(false);
+
+    await result.current.handleStartRun();
+    await flushRequests();
+
+    expect(result.current.isRunUninterruptible()).toBe(true);
+
+    releaseCreate({ success: true });
+    await flushRequests();
+
+    expect(result.current.isRunUninterruptible()).toBe(false);
+    expect(state.isRunning).toBe(false);
   });
 
   // Pausing during the setup pauses an animation that is about to be replaced by the one the run

--- a/src/hooks/useAnimation-run-state.test.tsx
+++ b/src/hooks/useAnimation-run-state.test.tsx
@@ -13,6 +13,9 @@ jest.mock("@concord-consortium/codap-plugin-api", () => ({
 }));
 
 jest.mock("../helpers/codap-helpers", () => ({
+  // tryRequest is a plain wrapper rather than a CODAP call, so the real one is what these tests
+  // should be running through
+  ...jest.requireActual("../helpers/codap-helpers"),
   findOrCreateDataContext: jest.fn(),
   getNewExperimentInfo: jest.fn(),
   getCollectionNames: jest.fn(() => ({ experiments: "experiments", samples: "samples", items: "items" })),
@@ -77,7 +80,10 @@ describe("handleStartRun run-state feedback", () => {
   beforeEach(() => {
     resetState();
     mockSetGlobalState.mockClear();
-    mockCreateItems.mockClear();
+    // reset rather than clear: several tests queue a mockImplementationOnce that never resolves, and
+    // clearing leaves an unconsumed one to be handed to whichever test calls createItems next
+    mockCreateItems.mockReset();
+    mockCreateItems.mockResolvedValue({ success: true });
     mockGetNewExperimentInfo.mockResolvedValue({ experimentNum: 1, startingSampleNumber: 1 });
     mockComputeExperimentHash.mockResolvedValue("hash");
   });

--- a/src/hooks/useAnimation-run-state.test.tsx
+++ b/src/hooks/useAnimation-run-state.test.tsx
@@ -1,0 +1,106 @@
+import { renderHook } from "@testing-library/react";
+import { findOrCreateDataContext, getNewExperimentInfo } from "../helpers/codap-helpers";
+import { computeExperimentHash } from "../helpers/model-helpers";
+import { useAnimationContextValue } from "./useAnimation";
+import { Speed } from "../types";
+
+jest.mock("@concord-consortium/codap-plugin-api", () => ({
+  createItems: jest.fn().mockResolvedValue({ caseIDs: [] }),
+  selectCases: jest.fn().mockResolvedValue({})
+}));
+
+jest.mock("../helpers/codap-helpers", () => ({
+  findOrCreateDataContext: jest.fn(),
+  getNewExperimentInfo: jest.fn(),
+  evaluateResult: jest.fn(() => true)
+}));
+
+jest.mock("../helpers/model-helpers", () => ({
+  computeExperimentHash: jest.fn(),
+  getExperimentDescription: jest.fn(() => "description"),
+  isSingleDeviceReplacement: jest.fn(() => true)
+}));
+
+// The hook reads global state through this context; a plain mutable object plus an immer-style
+// recipe runner is enough to observe the state transitions we care about.
+let state: any;
+const mockSetGlobalState = jest.fn((recipe: (draft: any) => void) => recipe(state));
+
+jest.mock("./useGlobalState", () => ({
+  useGlobalStateContext: () => ({ globalState: state, setGlobalState: mockSetGlobalState })
+}));
+
+const mockFindOrCreateDataContext = findOrCreateDataContext as jest.Mock;
+const mockGetNewExperimentInfo = getNewExperimentInfo as jest.Mock;
+const mockComputeExperimentHash = computeExperimentHash as jest.Mock;
+
+function resetState() {
+  state = {
+    speed: Speed.Fastest,
+    attrMap: {},
+    model: { columns: [{ id: "c1", name: "Deck1", devices: [{ id: "d1", viewType: "mixer", variables: ["a"], replacement: true, formulas: {} }] }] },
+    numSamples: "1",
+    sampleSize: "1",
+    dataContextName: "Sampler",
+    repeat: false,
+    untilFormula: "",
+    repeatCondition: "",
+    repeatNumUniqueValues: 1,
+    instance: 1,
+    isRunning: false,
+    isPaused: false,
+    enableRunButton: true
+  };
+}
+
+describe("handleStartRun run-state feedback", () => {
+  beforeEach(() => {
+    resetState();
+    mockSetGlobalState.mockClear();
+    mockGetNewExperimentInfo.mockResolvedValue({ experimentNum: 1, startingSampleNumber: 1 });
+    mockComputeExperimentHash.mockResolvedValue("hash");
+  });
+
+  // Collecting the samples requires many round-trips to CODAP, so the run can be under way for
+  // several seconds before any data appears. The controls must reflect that the run has started
+  // as soon as it is requested, not once the work lands.
+  it("marks the run as running before awaiting any CODAP request", async () => {
+    let releaseDataContext: (value: string) => void = () => undefined;
+    mockFindOrCreateDataContext.mockImplementation(
+      () => new Promise<string>(resolve => { releaseDataContext = resolve; }));
+
+    const { result } = renderHook(() => useAnimationContextValue());
+
+    const run = result.current.handleStartRun();
+
+    // the first CODAP request has not resolved yet
+    expect(state.isRunning).toBe(true);
+    expect(state.isPaused).toBe(false);
+    expect(state.enableRunButton).toBe(false);
+
+    releaseDataContext("Sampler");
+    await run;
+  });
+
+  it("re-enables the run button when the data context cannot be set up", async () => {
+    jest.spyOn(window, "alert").mockImplementation(() => undefined);
+    mockFindOrCreateDataContext.mockResolvedValue("");
+
+    const { result } = renderHook(() => useAnimationContextValue());
+    await result.current.handleStartRun();
+
+    expect(state.isRunning).toBe(false);
+    expect(state.enableRunButton).toBe(true);
+  });
+
+  it("re-enables the run button when starting the run throws", async () => {
+    jest.spyOn(window, "alert").mockImplementation(() => undefined);
+    mockFindOrCreateDataContext.mockRejectedValue(new Error("nope"));
+
+    const { result } = renderHook(() => useAnimationContextValue());
+    await result.current.handleStartRun();
+
+    expect(state.isRunning).toBe(false);
+    expect(state.enableRunButton).toBe(true);
+  });
+});

--- a/src/hooks/useAnimation-run-state.test.tsx
+++ b/src/hooks/useAnimation-run-state.test.tsx
@@ -273,6 +273,33 @@ describe("handleStartRun run-state feedback", () => {
     expect(state.isPaused).toBe(true);
   });
 
+  // Unless the run reaches the fastest speed before it starts animating, where it runs in one pass
+  // that no pause can reach. Carrying the pause over there would leave the controls offering to
+  // resume a run that never stopped.
+  it("drops a pause carried from setup when the run reaches the fastest speed", async () => {
+    state.speed = Speed.Slow;
+    let releaseDataContext: (value: string) => void = () => undefined;
+    mockFindOrCreateDataContext.mockImplementation(
+      () => new Promise<string>(resolve => { releaseDataContext = resolve; }));
+    // the run is still writing its samples when the pause is asserted on
+    mockCreateItems.mockImplementationOnce(() => new Promise(() => undefined));
+
+    const { result, rerender } = renderHook(() => useAnimationContextValue());
+
+    const run = result.current.handleStartRun();
+    await result.current.handleTogglePauseRun(true);
+
+    state.speed = Speed.Fastest;
+    rerender();
+
+    releaseDataContext("Sampler");
+    await run;
+    await flushRequests();
+
+    expect(state.isPaused).toBe(false);
+    expect(state.isRunning).toBe(true);
+  });
+
   it("re-enables the run button when the data context cannot be set up", async () => {
     jest.spyOn(window, "alert").mockImplementation(() => undefined);
     mockFindOrCreateDataContext.mockResolvedValue("");

--- a/src/hooks/useAnimation.test.tsx
+++ b/src/hooks/useAnimation.test.tsx
@@ -64,8 +64,8 @@ describe("createExperimentAnimationSteps endExperiment (Fastest mode)", () => {
     mockGetCaseByIndex.mockResolvedValue({ values: { case: { id: 77 } } });
   });
 
-  // Every sample goes to CODAP in one request: each create costs a pass over the whole dataset,
-  // so splitting the last sample out doubles the most expensive part of the operation.
+  // Every sample goes to CODAP in one request: a create costs a pass over the whole dataset, so
+  // each additional request roughly doubles the most expensive part of collecting an experiment.
   it("creates every sample in a single request", async () => {
     mockCreateItems.mockResolvedValue({});
     const onComplete = jest.fn();

--- a/src/hooks/useAnimation.test.tsx
+++ b/src/hooks/useAnimation.test.tsx
@@ -1,0 +1,157 @@
+import { createItems, selectCases } from "@concord-consortium/codap-plugin-api";
+import { createExperimentAnimationSteps } from "./useAnimation";
+import { Speed } from "../types";
+
+jest.mock("@concord-consortium/codap-plugin-api", () => ({
+  createItems: jest.fn(),
+  selectCases: jest.fn()
+}));
+
+jest.mock("../utils/localeManager", () => ({
+  tr: () => "sample"
+}));
+
+const mockCreateItems = createItems as jest.Mock;
+const mockSelectCases = selectCases as jest.Mock;
+
+// Two samples, one item each, from a single device. In Fastest mode the animation defers item
+// creation to the end of the experiment, where the LAST sample is popped off and created by a
+// second call — so two samples is the minimum that exercises both createItems calls.
+const model = {
+  columns: [{ id: "c1", name: "Deck1", devices: [{ id: "d1", replacement: true }] }]
+} as any;
+
+const animationResults = [
+  [{ sampleNumber: 1, results: { d1: "a" }, resultsVariableIndex: { d1: 0 } }],
+  [{ sampleNumber: 2, results: { d1: "b" }, resultsVariableIndex: { d1: 0 } }]
+] as any;
+
+const results = [
+  { sample: 1, Deck1: "a" },
+  { sample: 2, Deck1: "b" }
+] as any;
+
+/**
+ * Builds the steps, runs the per-sample `pushVariables` handlers at the given speed, then runs the
+ * `endExperiment` handler. At Fastest the samples are queued for end-of-experiment creation; at
+ * any other speed each sample is created as it is collected.
+ */
+async function runExperiment(onComplete: () => void, speed: Speed = Speed.Fastest) {
+  const steps = createExperimentAnimationSteps(model, "Sampler", animationResults, results, onComplete);
+
+  for (const step of steps) {
+    if (step.kind === "pushVariables") {
+      await (step as any).onComplete({ speed });
+    }
+  }
+
+  const endStep = steps.find(step => step.kind === "endExperiment") as any;
+  await endStep.onComplete();
+}
+
+describe("createExperimentAnimationSteps endExperiment (Fastest mode)", () => {
+  beforeEach(() => {
+    mockCreateItems.mockReset();
+    mockSelectCases.mockReset();
+    mockSelectCases.mockResolvedValue({});
+  });
+
+  it("creates the remaining samples, then the last sample, and completes", async () => {
+    mockCreateItems.mockResolvedValue({ caseIDs: ["c1"] });
+    const onComplete = jest.fn();
+
+    await runExperiment(onComplete);
+
+    expect(mockCreateItems).toHaveBeenCalledTimes(2);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  // A request that outlives the plugin API's deadline rejects even though CODAP may still be
+  // processing it successfully. That must not cost us the last sample, and must not strand the
+  // UI: the experiment has to finish either way.
+  it("still creates the last sample when the bulk create rejects", async () => {
+    mockCreateItems
+      .mockRejectedValueOnce("CODAP request timed out")
+      .mockResolvedValueOnce({ caseIDs: ["c1"] });
+    const onComplete = jest.fn();
+
+    await runExperiment(onComplete);
+
+    expect(mockCreateItems).toHaveBeenCalledTimes(2);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("completes when the last-sample create rejects", async () => {
+    mockCreateItems
+      .mockResolvedValueOnce({ caseIDs: ["c1"] })
+      .mockRejectedValueOnce("CODAP request timed out");
+    const onComplete = jest.fn();
+
+    await runExperiment(onComplete);
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("completes when selecting the new cases rejects", async () => {
+    mockCreateItems.mockResolvedValue({ caseIDs: ["c1"] });
+    mockSelectCases.mockRejectedValue("CODAP request timed out");
+    const onComplete = jest.fn();
+
+    await runExperiment(onComplete);
+
+    expect(mockSelectCases).toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reject out of endExperiment when every request fails", async () => {
+    mockCreateItems.mockRejectedValue("CODAP request timed out");
+    const onComplete = jest.fn();
+
+    await expect(runExperiment(onComplete)).resolves.toBeUndefined();
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createExperimentAnimationSteps pushVariables (per-sample creation)", () => {
+  beforeEach(() => {
+    mockCreateItems.mockReset();
+    mockSelectCases.mockReset();
+    mockSelectCases.mockResolvedValue({});
+  });
+
+  it("creates each sample as it is collected", async () => {
+    mockCreateItems.mockResolvedValue({ caseIDs: ["c1"] });
+    const onComplete = jest.fn();
+
+    await runExperiment(onComplete, Speed.Slow);
+
+    expect(mockCreateItems).toHaveBeenCalledTimes(2);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  // A sample whose create outlives the deadline must not abort the run — the samples that follow
+  // still need collecting, and the experiment still needs to finish.
+  it("keeps collecting later samples when one sample's create rejects", async () => {
+    mockCreateItems
+      .mockRejectedValueOnce("CODAP request timed out")
+      .mockResolvedValueOnce({ caseIDs: ["c1"] });
+    const onComplete = jest.fn();
+
+    await expect(runExperiment(onComplete, Speed.Slow)).resolves.toBeUndefined();
+
+    expect(mockCreateItems).toHaveBeenCalledTimes(2);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps collecting later samples when selecting a sample's cases rejects", async () => {
+    mockCreateItems.mockResolvedValue({ caseIDs: ["c1"] });
+    mockSelectCases.mockRejectedValue("CODAP request timed out");
+    const onComplete = jest.fn();
+
+    await expect(runExperiment(onComplete, Speed.Slow)).resolves.toBeUndefined();
+
+    expect(mockCreateItems).toHaveBeenCalledTimes(2);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useAnimation.test.tsx
+++ b/src/hooks/useAnimation.test.tsx
@@ -47,8 +47,8 @@ const results = [
  * `endExperiment` handler. At Fastest the samples are queued for end-of-experiment creation; at
  * any other speed each sample is created as it is collected.
  */
-async function runExperiment(onComplete: () => void, speed: Speed = Speed.Fastest) {
-  const steps = createExperimentAnimationSteps(model, "Sampler", animationResults, results, onComplete);
+async function runExperiment(onComplete: () => void, speed: Speed = Speed.Fastest, experimentResults = results) {
+  const steps = createExperimentAnimationSteps(model, "Sampler", animationResults, experimentResults, onComplete);
 
   for (const step of steps) {
     if (step.kind === "pushVariables") {
@@ -146,6 +146,22 @@ describe("createExperimentAnimationSteps endExperiment (Fastest mode)", () => {
     expect(mockGetCaseCount).not.toHaveBeenCalled();
     expect(mockGetCaseByIndex).not.toHaveBeenCalled();
     expect(mockSelectCases).not.toHaveBeenCalled();
+  });
+
+  // A sample can be animated without producing any rows — a device with no variables collects
+  // nothing — and creating no items succeeds without adding anything. There is then no sample just
+  // collected, so selecting the collection's last case would point at an earlier experiment's.
+  it("creates and selects nothing when the samples produced no rows", async () => {
+    mockCreateItems.mockResolvedValue({ success: true });
+    const onComplete = jest.fn();
+
+    await runExperiment(onComplete, Speed.Fastest, [] as any);
+
+    expect(mockCreateItems).not.toHaveBeenCalled();
+    expect(mockGetCaseCount).not.toHaveBeenCalled();
+    expect(mockGetCaseByIndex).not.toHaveBeenCalled();
+    expect(mockSelectCases).not.toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
   // CODAP answers a create it refuses rather than failing to answer, so a response is not by

--- a/src/hooks/useAnimation.test.tsx
+++ b/src/hooks/useAnimation.test.tsx
@@ -67,7 +67,7 @@ describe("createExperimentAnimationSteps endExperiment (Fastest mode)", () => {
   // Every sample goes to CODAP in one request: a create costs a pass over the whole dataset, so
   // each additional request roughly doubles the most expensive part of collecting an experiment.
   it("creates every sample in a single request", async () => {
-    mockCreateItems.mockResolvedValue({});
+    mockCreateItems.mockResolvedValue({ success: true });
     const onComplete = jest.fn();
 
     await runExperiment(onComplete);
@@ -84,7 +84,7 @@ describe("createExperimentAnimationSteps endExperiment (Fastest mode)", () => {
   // its items) is what makes the case table scroll to it and cascade to its children, because
   // CODAP resolves the ids it is given against each collection's rows.
   it("selects the last case in the sample collection", async () => {
-    mockCreateItems.mockResolvedValue({});
+    mockCreateItems.mockResolvedValue({ success: true });
     const onComplete = jest.fn();
 
     await runExperiment(onComplete);
@@ -94,7 +94,7 @@ describe("createExperimentAnimationSteps endExperiment (Fastest mode)", () => {
   });
 
   it("does not select anything when the sample collection is empty", async () => {
-    mockCreateItems.mockResolvedValue({});
+    mockCreateItems.mockResolvedValue({ success: true });
     mockGetCaseCount.mockResolvedValue({ values: 0 });
     const onComplete = jest.fn();
 
@@ -106,7 +106,7 @@ describe("createExperimentAnimationSteps endExperiment (Fastest mode)", () => {
   });
 
   it("completes when the last case cannot be looked up", async () => {
-    mockCreateItems.mockResolvedValue({});
+    mockCreateItems.mockResolvedValue({ success: true });
     mockGetCaseByIndex.mockRejectedValue("CODAP request timed out");
     const onComplete = jest.fn();
 
@@ -140,8 +140,22 @@ describe("createExperimentAnimationSteps endExperiment (Fastest mode)", () => {
     expect(mockSelectCases).not.toHaveBeenCalled();
   });
 
+  // CODAP answers a create it refuses rather than failing to answer, so a response is not by
+  // itself evidence that the samples landed.
+  it("selects nothing when the create is refused", async () => {
+    mockCreateItems.mockResolvedValue({ success: false, values: { error: "no such collection" } });
+    const onComplete = jest.fn();
+
+    await runExperiment(onComplete);
+
+    expect(mockGetCaseCount).not.toHaveBeenCalled();
+    expect(mockGetCaseByIndex).not.toHaveBeenCalled();
+    expect(mockSelectCases).not.toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
   it("completes when selecting the new cases rejects", async () => {
-    mockCreateItems.mockResolvedValue({});
+    mockCreateItems.mockResolvedValue({ success: true });
     mockSelectCases.mockRejectedValue("CODAP request timed out");
     const onComplete = jest.fn();
 

--- a/src/hooks/useAnimation.test.tsx
+++ b/src/hooks/useAnimation.test.tsx
@@ -9,8 +9,15 @@ jest.mock("@concord-consortium/codap-plugin-api", () => ({
   getCaseByIndex: jest.fn()
 }));
 
+// Distinct names per key: which collection the last case is read from is the point of these
+// tests, and a mock that answered every key alike could not tell the three collections apart.
 jest.mock("../utils/localeManager", () => ({
-  tr: () => "sample"
+  tr: (key: string) => ({
+    "DG.Plugin.Sampler.dataset.attr-sample": "sample",
+    "DG.Plugin.Sampler.dataset.experiment-collection-name": "experiments",
+    "DG.Plugin.Sampler.dataset.sample-collection-name": "samples",
+    "DG.Plugin.Sampler.dataset.item-collection-name": "items"
+  } as Record<string, string>)[key] ?? key
 }));
 
 const mockCreateItems = createItems as jest.Mock;
@@ -89,7 +96,8 @@ describe("createExperimentAnimationSteps endExperiment (Fastest mode)", () => {
 
     await runExperiment(onComplete);
 
-    expect(mockGetCaseByIndex).toHaveBeenCalledWith("Sampler", expect.anything(), 1);
+    expect(mockGetCaseCount).toHaveBeenCalledWith("Sampler", "samples");
+    expect(mockGetCaseByIndex).toHaveBeenCalledWith("Sampler", "samples", 1);
     expect(mockSelectCases).toHaveBeenCalledWith("Sampler", [77]);
   });
 

--- a/src/hooks/useAnimation.test.tsx
+++ b/src/hooks/useAnimation.test.tsx
@@ -1,10 +1,12 @@
-import { createItems, selectCases } from "@concord-consortium/codap-plugin-api";
+import { createItems, getCaseByIndex, getCaseCount, selectCases } from "@concord-consortium/codap-plugin-api";
 import { createExperimentAnimationSteps } from "./useAnimation";
 import { Speed } from "../types";
 
 jest.mock("@concord-consortium/codap-plugin-api", () => ({
   createItems: jest.fn(),
-  selectCases: jest.fn()
+  selectCases: jest.fn(),
+  getCaseCount: jest.fn(),
+  getCaseByIndex: jest.fn()
 }));
 
 jest.mock("../utils/localeManager", () => ({
@@ -13,10 +15,12 @@ jest.mock("../utils/localeManager", () => ({
 
 const mockCreateItems = createItems as jest.Mock;
 const mockSelectCases = selectCases as jest.Mock;
+const mockGetCaseCount = getCaseCount as jest.Mock;
+const mockGetCaseByIndex = getCaseByIndex as jest.Mock;
 
 // Two samples, one item each, from a single device. In Fastest mode the animation defers item
-// creation to the end of the experiment, where the LAST sample is popped off and created by a
-// second call — so two samples is the minimum that exercises both createItems calls.
+// creation to the end of the experiment, so two samples is enough to distinguish "created every
+// sample together" from "created them one at a time".
 const model = {
   columns: [{ id: "c1", name: "Deck1", devices: [{ id: "d1", replacement: true }] }]
 } as any;
@@ -53,38 +57,69 @@ describe("createExperimentAnimationSteps endExperiment (Fastest mode)", () => {
   beforeEach(() => {
     mockCreateItems.mockReset();
     mockSelectCases.mockReset();
+    mockGetCaseCount.mockReset();
+    mockGetCaseByIndex.mockReset();
     mockSelectCases.mockResolvedValue({});
+    mockGetCaseCount.mockResolvedValue({ values: 2 });
+    mockGetCaseByIndex.mockResolvedValue({ values: { case: { id: 77 } } });
   });
 
-  it("creates the remaining samples, then the last sample, and completes", async () => {
-    mockCreateItems.mockResolvedValue({ caseIDs: ["c1"] });
+  // Every sample goes to CODAP in one request: each create costs a pass over the whole dataset,
+  // so splitting the last sample out doubles the most expensive part of the operation.
+  it("creates every sample in a single request", async () => {
+    mockCreateItems.mockResolvedValue({});
     const onComplete = jest.fn();
 
     await runExperiment(onComplete);
 
-    expect(mockCreateItems).toHaveBeenCalledTimes(2);
+    expect(mockCreateItems).toHaveBeenCalledTimes(1);
+    expect(mockCreateItems).toHaveBeenCalledWith("Sampler", [
+      { sample: 1, Deck1: "a" },
+      { sample: 2, Deck1: "b" }
+    ]);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  // The sample collection's last case is the one just collected. Selecting that case (rather than
+  // its items) is what makes the case table scroll to it and cascade to its children, because
+  // CODAP resolves the ids it is given against each collection's rows.
+  it("selects the last case in the sample collection", async () => {
+    mockCreateItems.mockResolvedValue({});
+    const onComplete = jest.fn();
+
+    await runExperiment(onComplete);
+
+    expect(mockGetCaseByIndex).toHaveBeenCalledWith("Sampler", expect.anything(), 1);
+    expect(mockSelectCases).toHaveBeenCalledWith("Sampler", [77]);
+  });
+
+  it("does not select anything when the sample collection is empty", async () => {
+    mockCreateItems.mockResolvedValue({});
+    mockGetCaseCount.mockResolvedValue({ values: 0 });
+    const onComplete = jest.fn();
+
+    await runExperiment(onComplete);
+
+    expect(mockGetCaseByIndex).not.toHaveBeenCalled();
+    expect(mockSelectCases).not.toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("completes when the last case cannot be looked up", async () => {
+    mockCreateItems.mockResolvedValue({});
+    mockGetCaseByIndex.mockRejectedValue("CODAP request timed out");
+    const onComplete = jest.fn();
+
+    await runExperiment(onComplete);
+
+    expect(mockSelectCases).not.toHaveBeenCalled();
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
   // A request that outlives the plugin API's deadline rejects even though CODAP may still be
-  // processing it successfully. That must not cost us the last sample, and must not strand the
-  // UI: the experiment has to finish either way.
-  it("still creates the last sample when the bulk create rejects", async () => {
-    mockCreateItems
-      .mockRejectedValueOnce("CODAP request timed out")
-      .mockResolvedValueOnce({ caseIDs: ["c1"] });
-    const onComplete = jest.fn();
-
-    await runExperiment(onComplete);
-
-    expect(mockCreateItems).toHaveBeenCalledTimes(2);
-    expect(onComplete).toHaveBeenCalledTimes(1);
-  });
-
-  it("completes when the last-sample create rejects", async () => {
-    mockCreateItems
-      .mockResolvedValueOnce({ caseIDs: ["c1"] })
-      .mockRejectedValueOnce("CODAP request timed out");
+  // processing it successfully. That must not strand the UI: the experiment has to finish.
+  it("completes when the create rejects", async () => {
+    mockCreateItems.mockRejectedValue("CODAP request timed out");
     const onComplete = jest.fn();
 
     await runExperiment(onComplete);
@@ -93,7 +128,7 @@ describe("createExperimentAnimationSteps endExperiment (Fastest mode)", () => {
   });
 
   it("completes when selecting the new cases rejects", async () => {
-    mockCreateItems.mockResolvedValue({ caseIDs: ["c1"] });
+    mockCreateItems.mockResolvedValue({});
     mockSelectCases.mockRejectedValue("CODAP request timed out");
     const onComplete = jest.fn();
 

--- a/src/hooks/useAnimation.test.tsx
+++ b/src/hooks/useAnimation.test.tsx
@@ -127,6 +127,19 @@ describe("createExperimentAnimationSteps endExperiment (Fastest mode)", () => {
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
+  // Without a create that landed, the sample collection's last case may belong to an earlier
+  // experiment, and selecting it would claim it is the sample just collected.
+  it("selects nothing when the create rejects", async () => {
+    mockCreateItems.mockRejectedValue("CODAP request timed out");
+    const onComplete = jest.fn();
+
+    await runExperiment(onComplete);
+
+    expect(mockGetCaseCount).not.toHaveBeenCalled();
+    expect(mockGetCaseByIndex).not.toHaveBeenCalled();
+    expect(mockSelectCases).not.toHaveBeenCalled();
+  });
+
   it("completes when selecting the new cases rejects", async () => {
     mockCreateItems.mockResolvedValue({});
     mockSelectCases.mockRejectedValue("CODAP request timed out");

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -545,6 +545,12 @@ export const useAnimationContextValue = (): IAnimationContext => {
       }
 
       const onEndRun = () => {
+        // The steps hold on to this, and a request they are waiting on can settle long after the
+        // run was stopped or replaced. Ending a run that is no longer the one under way would
+        // hand its controls back over a run that is still going.
+        if (!isCurrentRun()) {
+          return;
+        }
         animationsCallbacksRef.current.forEach(callback => callback({ kind: "endExperiment" }));
         enableNewRun();
       };

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -40,9 +40,9 @@ const instantStepsInFastMode: string[] = [
  * Issues a CODAP request, reporting rather than propagating a failure.
  *
  * A large request can exceed the plugin API's response deadline and reject while CODAP is still
- * processing it successfully, so a rejection here does not mean the work failed — it means we
- * stopped waiting. Letting that escape would abandon the steps that follow, which is how an
- * experiment ends up one sample short with its controls stuck mid-run.
+ * processing it successfully, so a rejection does not mean the work failed — only that we stopped
+ * waiting for it. Since the outcome is unknown either way, an experiment should carry on to its
+ * remaining steps and finish rather than abandoning them.
  */
 const tryRequest = async <T,>(request: () => Promise<T>): Promise<T | undefined> => {
   try {
@@ -107,8 +107,8 @@ export const createExperimentAnimationSteps = (model: IModel, dataContextName: s
             // in fastest mode the samples are created at the end of the experiment
             finalSampleResults.push(sampleResults);
           } else {
-            // As at the end of the experiment, a request that outlives the response deadline must
-            // not abort the animation — the remaining samples still need to be collected.
+            // A request that outlives the response deadline must not abort the animation — the
+            // samples after this one still need collecting.
             const createItemsResult =
               await tryRequest(() => createItems(dataContextName, sampleResults)) as any;
             if (createItemsResult?.caseIDs) {
@@ -122,9 +122,9 @@ export const createExperimentAnimationSteps = (model: IModel, dataContextName: s
   });
 
   steps.push({ kind: "endExperiment", onComplete: async () => {
-    // Each request is issued through tryRequest so that one that outlives the response deadline
-    // costs at most its own result: the last sample is still created, and the experiment still
-    // finishes. onComplete runs from a finally so the controls can never be left mid-run.
+    // Requests go through tryRequest so a slow one costs at most its own result rather than the
+    // steps after it, and onComplete runs from a finally, so the experiment always reports itself
+    // finished and the controls are never left mid-run.
     try {
       // in fastest mode the samples are created at the end of the experiment
       if (finalSampleResults.length > 0) {
@@ -133,16 +133,16 @@ export const createExperimentAnimationSteps = (model: IModel, dataContextName: s
           mergedFinalSampleResults.push(...sampleResults);
         }
 
-        // Every sample goes over in a single request. CODAP costs a create by the size of the
-        // whole dataset rather than by the number of items sent, so a second request for the
-        // last sample alone is nearly as expensive as the first.
+        // The whole experiment goes over in one request. CODAP prices a create by the size of the
+        // dataset it is added to rather than by the number of items sent, so each additional
+        // request costs about as much as the first however little it carries.
         await tryRequest(() => createItems(dataContextName, mergedFinalSampleResults));
 
         // Samples are appended in order, so the sample collection's last case is the one just
         // collected. Select the case rather than its items: CODAP resolves the ids it is given
-        // against each collection's rows, so naming the case is what scrolls the table to it and
-        // cascades that scroll to its children. Two small reads to find it are far cheaper than
-        // the extra create that separating the last sample would cost.
+        // against each collection's rows, and naming the case is what scrolls the table to it and
+        // cascades that scroll to its children. Reading the case back costs far less than
+        // arranging for the create to report it.
         const sampleCollectionName = getCollectionNames().samples;
         const caseCountResult =
           await tryRequest(() => getCaseCount(dataContextName, sampleCollectionName)) as any;

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -136,23 +136,29 @@ export const createExperimentAnimationSteps = (model: IModel, dataContextName: s
         // The whole experiment goes over in one request. CODAP prices a create by the size of the
         // dataset it is added to rather than by the number of items sent, so each additional
         // request costs about as much as the first however little it carries.
-        await tryRequest(() => createItems(dataContextName, mergedFinalSampleResults));
+        const created = await tryRequest(() => createItems(dataContextName, mergedFinalSampleResults));
 
         // Samples are appended in order, so the sample collection's last case is the one just
         // collected. Select the case rather than its items: CODAP resolves the ids it is given
         // against each collection's rows, and naming the case is what scrolls the table to it and
         // cascades that scroll to its children. Reading the case back costs far less than
         // arranging for the create to report it.
-        const sampleCollectionName = getCollectionNames().samples;
-        const caseCountResult =
-          await tryRequest(() => getCaseCount(dataContextName, sampleCollectionName)) as any;
-        const sampleCount = caseCountResult?.values;
-        if (typeof sampleCount === "number" && sampleCount > 0) {
-          const lastCaseResult = await tryRequest(
-            () => getCaseByIndex(dataContextName, sampleCollectionName, sampleCount - 1)) as any;
-          const lastSampleCaseId = lastCaseResult?.values?.case?.id;
-          if (lastSampleCaseId != null) {
-            await tryRequest(() => selectCases(dataContextName, [lastSampleCaseId]));
+        //
+        // Only once the create is known to have landed, though. Otherwise the last case may belong
+        // to an earlier experiment, and highlighting it would claim it is the sample just
+        // collected. Selecting nothing says nothing; selecting the wrong row misleads.
+        if (created) {
+          const sampleCollectionName = getCollectionNames().samples;
+          const caseCountResult =
+            await tryRequest(() => getCaseCount(dataContextName, sampleCollectionName)) as any;
+          const sampleCount = caseCountResult?.values;
+          if (typeof sampleCount === "number" && sampleCount > 0) {
+            const lastCaseResult = await tryRequest(
+              () => getCaseByIndex(dataContextName, sampleCollectionName, sampleCount - 1)) as any;
+            const lastSampleCaseId = lastCaseResult?.values?.case?.id;
+            if (lastSampleCaseId != null) {
+              await tryRequest(() => selectCases(dataContextName, [lastSampleCaseId]));
+            }
           }
         }
       }

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -471,11 +471,22 @@ export const useAnimationContextValue = (): IAnimationContext => {
   };
 
   const handleStartRun = async () => {
+    // Mark the run as under way before issuing any request. Setting up the data context and
+    // collecting the samples takes many round-trips to CODAP — seconds, on a large experiment —
+    // and until this lands the controls still invite the user to start a run that is already
+    // running, with nothing to show that anything is happening.
+    setGlobalState(draft => {
+      draft.isRunning = true;
+      draft.isPaused = false;
+      draft.enableRunButton = false;
+    });
+
     try {
       const isCollector = isCollectorOnlyModel(model);
       const attrNames = isCollector ? getCollectorAttrs(model) : getModelAttrs(model);
       const finalDataContextName = await findOrCreateDataContext(dataContextName, attrNames, attrMap, setGlobalState, repeat, isCollector, globalState.instance, true);
       if (!finalDataContextName) {
+        enableNewRun();
         alert("Unable to setup CODAP table");
         return;
       }
@@ -488,12 +499,6 @@ export const useAnimationContextValue = (): IAnimationContext => {
       const { experimentNum, startingSampleNumber } = await getNewExperimentInfo(finalDataContextName, experimentHash);
 
       const { results, animationResults } = await getAllExperimentSamples(experimentNum, startingSampleNumber, experimentHash);
-
-      setGlobalState(draft => {
-        draft.isRunning = true;
-        draft.isPaused = false;
-        draft.enableRunButton = false;
-      });
 
       const onEndRun = () => {
         animationsCallbacksRef.current.forEach(callback => callback({ kind: "endExperiment" }));

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -585,7 +585,11 @@ export const useAnimationContextValue = (): IAnimationContext => {
       }
       stopAnimation();
       enableNewRun();
-      alert(e);
+      // The run's own failures — an until formula that cannot be evaluated, samples that never
+      // satisfied it — carry a message written for the user. Anything else is a rejection string
+      // written for a developer, which belongs in the console.
+      console.warn("Sampler: could not run the experiment:", e);
+      alert(e instanceof Error ? e.message : "Unable to run the experiment. Please try again.");
     }
   };
 

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -94,7 +94,9 @@ export const createExperimentAnimationSteps = (model: IModel, dataContextName: s
             // samples after this one still need collecting.
             const createItemsResult =
               await tryRequest(() => createItems(dataContextName, sampleResults)) as any;
-            if (createItemsResult?.caseIDs) {
+            // a run the user stopped or replaced must not move the selection over the one
+            // that took its place
+            if (createItemsResult?.caseIDs && isCurrentRun()) {
               await tryRequest(() => selectCases(dataContextName, createItemsResult.caseIDs));
             }
           }
@@ -105,9 +107,8 @@ export const createExperimentAnimationSteps = (model: IModel, dataContextName: s
   });
 
   steps.push({ kind: "endExperiment", onComplete: async () => {
-    // Requests go through tryRequest so a slow one costs at most its own result rather than the
-    // steps after it, and onComplete runs from a finally, so the experiment always reports itself
-    // finished and the controls are never left mid-run.
+    // onComplete runs from a finally: whatever becomes of these requests, the experiment reports
+    // itself finished and the controls are never left mid-run.
     try {
       // in fastest mode the samples are created at the end of the experiment
       if (finalSampleResults.length > 0) {
@@ -129,17 +130,16 @@ export const createExperimentAnimationSteps = (model: IModel, dataContextName: s
         const created = await tryRequest(() => createItems(dataContextName, mergedFinalSampleResults));
 
         // Samples are appended in order, so the sample collection's last case is the one just
-        // collected. Select the case rather than its items: CODAP resolves the ids it is given
-        // against each collection's rows, and naming the case is what scrolls the table to it and
-        // cascades that scroll to its children. Reading the case back costs far less than
-        // arranging for the create to report it.
+        // collected. Selecting the case rather than its items is what scrolls the table to it and
+        // cascades that scroll to its children, and reading it back costs far less than arranging
+        // for the create to report it.
         //
-        // Only once the create is known to have landed, though. Otherwise the last case may belong
-        // to an earlier experiment, and highlighting it would claim it is the sample just
-        // collected. Selecting nothing says nothing; selecting the wrong row misleads. A refused
-        // create resolves with success false rather than rejecting, so the request has to be asked
-        // whether it worked, not merely whether it answered.
-        if (created?.success) {
+        // Both conditions carry weight. A refused create resolves with success false rather than
+        // rejecting, so the request has to be asked whether it worked and not merely whether it
+        // answered; without a create that landed, the last case may belong to an earlier
+        // experiment. And a stopped or superseded run would scroll the table away from the run
+        // collecting now. Selecting nothing says nothing; selecting the wrong row misleads.
+        if (created?.success && isCurrentRun()) {
           const sampleCollectionName = getCollectionNames().samples;
           const caseCountResult =
             await tryRequest(() => getCaseCount(dataContextName, sampleCollectionName)) as any;
@@ -555,7 +555,7 @@ export const useAnimationContextValue = (): IAnimationContext => {
         enableNewRun();
       };
 
-      const newAnimationSteps = createExperimentAnimationSteps(model, finalDataContextName, animationResults, results, onEndRun);
+      const newAnimationSteps = createExperimentAnimationSteps(model, finalDataContextName, animationResults, results, onEndRun, isCurrentRun);
       startAnimation(newAnimationSteps);
       // startAnimation runs whatever it is given, so a pause requested during the setup has to be
       // re-applied to the animation it just replaced — unless the run has reached the fastest

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -48,7 +48,7 @@ const tryRequest = async <T,>(request: () => Promise<T>): Promise<T | undefined>
   try {
     return await request();
   } catch (error) {
-    console.warn("Sampler: CODAP request did not complete:", error); // eslint-disable-line no-console
+    console.warn("Sampler: CODAP request did not complete:", error);
     return undefined;
   }
 };

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -146,8 +146,10 @@ export const createExperimentAnimationSteps = (model: IModel, dataContextName: s
         //
         // Only once the create is known to have landed, though. Otherwise the last case may belong
         // to an earlier experiment, and highlighting it would claim it is the sample just
-        // collected. Selecting nothing says nothing; selecting the wrong row misleads.
-        if (created) {
+        // collected. Selecting nothing says nothing; selecting the wrong row misleads. A refused
+        // create resolves with success false rather than rejecting, so the request has to be asked
+        // whether it worked, not merely whether it answered.
+        if (created?.success) {
           const sampleCollectionName = getCollectionNames().samples;
           const caseCountResult =
             await tryRequest(() => getCaseCount(dataContextName, sampleCollectionName)) as any;

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -190,6 +190,8 @@ export const useAnimationContextValue = (): IAnimationContext => {
   // it should begin paused.
   const runIdRef = useRef<number>(0);
   const isPausedRef = useRef<boolean>(false);
+  // set once the run enters the single pass that finishes it, which nothing can pause part-way
+  const uninterruptibleRunRef = useRef<boolean>(false);
   const globalReplacement = isSingleDeviceReplacement(model);
 
   const getExperimentSample = async (variableIndexes: AvailableDeviceVariableIndexes) => {
@@ -437,6 +439,7 @@ export const useAnimationContextValue = (): IAnimationContext => {
   };
 
   const startAnimation = (newAnimationSteps: AnimationStep[]) => {
+    uninterruptibleRunRef.current = false;
     animationRef.current = {
       frame: 0,
       steps: newAnimationSteps,
@@ -460,6 +463,9 @@ export const useAnimationContextValue = (): IAnimationContext => {
 
     // instantly finish all the steps if we start or change to fastest speed
     if (speedRef.current === Speed.Fastest) {
+      // this pass runs to the end of the experiment whatever the speed does from here, so the
+      // controls have to know that pausing can no longer reach it
+      uninterruptibleRunRef.current = true;
       const finish = async () => {
         const startedFinishAt = Date.now();
         const settings: IAnimationStepSettings = { t: 1, speed: Speed.Fastest };
@@ -487,6 +493,7 @@ export const useAnimationContextValue = (): IAnimationContext => {
 
   const enableNewRun = () => {
     isPausedRef.current = false;
+    uninterruptibleRunRef.current = false;
     setGlobalState(draft => {
       draft.isRunning = false;
       draft.isPaused = false;
@@ -597,6 +604,7 @@ export const useAnimationContextValue = (): IAnimationContext => {
     handleStartRun,
     handleTogglePauseRun,
     handleStopRun,
+    isRunUninterruptible: () => uninterruptibleRunRef.current,
     registerAnimationCallback
   };
 };
@@ -605,6 +613,7 @@ export const AnimationContext = createContext<IAnimationContext>({
   handleStartRun: () => Promise.resolve(),
   handleTogglePauseRun: (pause: boolean) => Promise.resolve(),
   handleStopRun: () => Promise.resolve(),
+  isRunUninterruptible: () => false,
   registerAnimationCallback: () => () => undefined
 });
 export const useAnimationContext = () => useContext(AnimationContext);

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useEffect, useRef } from "react";
 import { AnimationCallback, AnimationStep, IAnimationContext, IAnimationRuntime, IAnimationStepSettings, IExperimentResults, IExperimentAnimationResults, IModel, ISampleResults, Speed, ISampleVariableIndexes, AvailableDeviceVariableIndexes, ViewType } from "../types";
 import { createItems, getCaseByIndex, getCaseCount, selectCases } from "@concord-consortium/codap-plugin-api";
 import { useGlobalStateContext } from "./useGlobalState";
-import { evaluateResult, findOrCreateDataContext, getCollectionNames, getNewExperimentInfo } from "../helpers/codap-helpers";
+import { evaluateResult, findOrCreateDataContext, getCollectionNames, getNewExperimentInfo, tryRequest } from "../helpers/codap-helpers";
 import { getDeviceById } from "../models/model-model";
 import { formatFormula, parseFormula } from "../utils/utils";
 import { computeExperimentHash, getExperimentDescription, isSingleDeviceReplacement } from "../helpers/model-helpers";
@@ -36,24 +36,7 @@ const instantStepsInFastMode: string[] = [
   "pushVariables",
 ];
 
-/**
- * Issues a CODAP request, reporting rather than propagating a failure.
- *
- * A large request can exceed the plugin API's response deadline and reject while CODAP is still
- * processing it successfully, so a rejection does not mean the work failed — only that we stopped
- * waiting for it. Since the outcome is unknown either way, an experiment should carry on to its
- * remaining steps and finish rather than abandoning them.
- */
-const tryRequest = async <T,>(request: () => Promise<T>): Promise<T | undefined> => {
-  try {
-    return await request();
-  } catch (error) {
-    console.warn("Sampler: CODAP request did not complete:", error);
-    return undefined;
-  }
-};
-
-export const createExperimentAnimationSteps = (model: IModel, dataContextName: string, animationResults: IExperimentAnimationResults, results: IExperimentResults, onComplete?: () => void): Array<AnimationStep> => {
+export const createExperimentAnimationSteps = (model: IModel, dataContextName: string, animationResults: IExperimentAnimationResults, results: IExperimentResults, onComplete?: () => void, isCurrentRun: () => boolean = () => true): Array<AnimationStep> => {
   const steps: AnimationStep[] = [];
   const finalSampleResults: ISampleResults[][] = [];
 

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -184,6 +184,12 @@ export const useAnimationContextValue = (): IAnimationContext => {
   const animationsCallbacksRef = useRef<AnimationCallback[]>([]);
   const speedRef = useRef<Speed>(Speed.Slow);
   const stopAnimationAtRef = useRef<number>(0);
+  // A run is set up before it animates, so the controls act on it while there is no animation to
+  // act on. These record what the user asked for during the setup so the run can honor it once it
+  // has something to animate: the id identifies the run still wanted, and the pause flag whether
+  // it should begin paused.
+  const runIdRef = useRef<number>(0);
+  const isPausedRef = useRef<boolean>(false);
   const globalReplacement = isSingleDeviceReplacement(model);
 
   const getExperimentSample = async (variableIndexes: AvailableDeviceVariableIndexes) => {
@@ -480,6 +486,7 @@ export const useAnimationContextValue = (): IAnimationContext => {
   };
 
   const enableNewRun = () => {
+    isPausedRef.current = false;
     setGlobalState(draft => {
       draft.isRunning = false;
       draft.isPaused = false;
@@ -492,16 +499,26 @@ export const useAnimationContextValue = (): IAnimationContext => {
     // collecting the samples takes many round-trips to CODAP — seconds, on a large experiment —
     // and until this lands the controls still invite the user to start a run that is already
     // running, with nothing to show that anything is happening.
+    const runId = ++runIdRef.current;
+    isPausedRef.current = false;
     setGlobalState(draft => {
       draft.isRunning = true;
       draft.isPaused = false;
       draft.enableRunButton = false;
     });
 
+    // The run being set up is only still wanted while it is the most recent one requested: stopping
+    // it, or starting another, leaves it to abandon itself, since there is no animation yet for
+    // those to act on.
+    const isCurrentRun = () => runIdRef.current === runId;
+
     try {
       const isCollector = isCollectorOnlyModel(model);
       const attrNames = isCollector ? getCollectorAttrs(model) : getModelAttrs(model);
       const finalDataContextName = await findOrCreateDataContext(dataContextName, attrNames, attrMap, setGlobalState, repeat, isCollector, globalState.instance, true);
+      if (!isCurrentRun()) {
+        return;
+      }
       if (!finalDataContextName) {
         enableNewRun();
         alert("Unable to setup CODAP table");
@@ -516,6 +533,9 @@ export const useAnimationContextValue = (): IAnimationContext => {
       const { experimentNum, startingSampleNumber } = await getNewExperimentInfo(finalDataContextName, experimentHash);
 
       const { results, animationResults } = await getAllExperimentSamples(experimentNum, startingSampleNumber, experimentHash);
+      if (!isCurrentRun()) {
+        return;
+      }
 
       const onEndRun = () => {
         animationsCallbacksRef.current.forEach(callback => callback({ kind: "endExperiment" }));
@@ -524,7 +544,16 @@ export const useAnimationContextValue = (): IAnimationContext => {
 
       const newAnimationSteps = createExperimentAnimationSteps(model, finalDataContextName, animationResults, results, onEndRun);
       startAnimation(newAnimationSteps);
+      // startAnimation runs whatever it is given, so a pause requested during the setup has to be
+      // re-applied to the animation it just replaced.
+      if (isPausedRef.current) {
+        togglePauseAnimation(true);
+      }
     } catch (e) {
+      if (!isCurrentRun()) {
+        console.warn("Sampler: abandoned run failed to start:", e);
+        return;
+      }
       stopAnimation();
       enableNewRun();
       alert(e);
@@ -532,6 +561,7 @@ export const useAnimationContextValue = (): IAnimationContext => {
   };
 
   const handleTogglePauseRun = async (pause: boolean) => {
+    isPausedRef.current = pause;
     togglePauseAnimation(pause);
     setGlobalState(draft => {
       draft.isPaused = pause;
@@ -539,6 +569,8 @@ export const useAnimationContextValue = (): IAnimationContext => {
   };
 
   const handleStopRun = async () => {
+    // Abandon a run that is still being set up; stopAnimation only reaches one that is animating.
+    runIdRef.current++;
     stopAnimation();
     animationsCallbacksRef.current.forEach(callback => callback({ kind: "endExperiment" }));
     enableNewRun();

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -1,8 +1,8 @@
 import { createContext, useContext, useEffect, useRef } from "react";
 import { AnimationCallback, AnimationStep, IAnimationContext, IAnimationRuntime, IAnimationStepSettings, IExperimentResults, IExperimentAnimationResults, IModel, ISampleResults, Speed, ISampleVariableIndexes, AvailableDeviceVariableIndexes, ViewType } from "../types";
-import { createItems, selectCases } from "@concord-consortium/codap-plugin-api";
+import { createItems, getCaseByIndex, getCaseCount, selectCases } from "@concord-consortium/codap-plugin-api";
 import { useGlobalStateContext } from "./useGlobalState";
-import { evaluateResult, findOrCreateDataContext, getNewExperimentInfo } from "../helpers/codap-helpers";
+import { evaluateResult, findOrCreateDataContext, getCollectionNames, getNewExperimentInfo } from "../helpers/codap-helpers";
 import { getDeviceById } from "../models/model-model";
 import { formatFormula, parseFormula } from "../utils/utils";
 import { computeExperimentHash, getExperimentDescription, isSingleDeviceReplacement } from "../helpers/model-helpers";
@@ -128,22 +128,31 @@ export const createExperimentAnimationSteps = (model: IModel, dataContextName: s
     try {
       // in fastest mode the samples are created at the end of the experiment
       if (finalSampleResults.length > 0) {
-        // create all but the last set of samples in one shot
-        const lastSampleResults = finalSampleResults.pop();
-        if (finalSampleResults.length > 0) {
-          const mergedFinalSampleResults: ISampleResults[] = [];
-          for (const sampleResults of finalSampleResults) {
-            mergedFinalSampleResults.push(...sampleResults);
-          }
-          await tryRequest(() => createItems(dataContextName, mergedFinalSampleResults));
+        const mergedFinalSampleResults: ISampleResults[] = [];
+        for (const sampleResults of finalSampleResults) {
+          mergedFinalSampleResults.push(...sampleResults);
         }
 
-        // create the last set of samples and select them
-        if (lastSampleResults) {
-          const createItemsResult =
-            await tryRequest(() => createItems(dataContextName, lastSampleResults)) as any;
-          if (createItemsResult?.caseIDs) {
-            await tryRequest(() => selectCases(dataContextName, createItemsResult.caseIDs));
+        // Every sample goes over in a single request. CODAP costs a create by the size of the
+        // whole dataset rather than by the number of items sent, so a second request for the
+        // last sample alone is nearly as expensive as the first.
+        await tryRequest(() => createItems(dataContextName, mergedFinalSampleResults));
+
+        // Samples are appended in order, so the sample collection's last case is the one just
+        // collected. Select the case rather than its items: CODAP resolves the ids it is given
+        // against each collection's rows, so naming the case is what scrolls the table to it and
+        // cascades that scroll to its children. Two small reads to find it are far cheaper than
+        // the extra create that separating the last sample would cost.
+        const sampleCollectionName = getCollectionNames().samples;
+        const caseCountResult =
+          await tryRequest(() => getCaseCount(dataContextName, sampleCollectionName)) as any;
+        const sampleCount = caseCountResult?.values;
+        if (typeof sampleCount === "number" && sampleCount > 0) {
+          const lastCaseResult = await tryRequest(
+            () => getCaseByIndex(dataContextName, sampleCollectionName, sampleCount - 1)) as any;
+          const lastSampleCaseId = lastCaseResult?.values?.case?.id;
+          if (lastSampleCaseId != null) {
+            await tryRequest(() => selectCases(dataContextName, [lastSampleCaseId]));
           }
         }
       }

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -461,11 +461,21 @@ export const useAnimationContextValue = (): IAnimationContext => {
         const settings: IAnimationStepSettings = { t: 1, speed: Speed.Fastest };
         const endAnimations = () => animationsCallbacksRef.current.forEach(callback => callback({kind: "endExperiment"}, settings));
 
+        // The pass walks the steps of the run it started on. A step can still be awaiting CODAP
+        // when the user stops and starts again, and by then animationRef holds the run that
+        // replaced this one -- reading it again below would step and end that run instead.
+        const runtime = animationRef.current;
+
         // run through all the steps and call onComplete for each one
-        while (animationRef.current.stepIndex < animationRef.current.steps.length) {
-          const step = animationRef.current.steps[animationRef.current.stepIndex];
+        while (runtime.stepIndex < runtime.steps.length) {
+          const step = runtime.steps[runtime.stepIndex];
           await step.onComplete?.(settings);
-          animationRef.current.stepIndex++;
+
+          // superseded while that step was in flight: the replacement owns the animation now
+          if (animationRef.current !== runtime) {
+            return;
+          }
+          runtime.stepIndex++;
 
           if (stopAnimationAtRef.current > startedFinishAt) {
             // if we were asked to stop while finishing, stop immediately

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -36,6 +36,23 @@ const instantStepsInFastMode: string[] = [
   "pushVariables",
 ];
 
+/**
+ * Issues a CODAP request, reporting rather than propagating a failure.
+ *
+ * A large request can exceed the plugin API's response deadline and reject while CODAP is still
+ * processing it successfully, so a rejection here does not mean the work failed — it means we
+ * stopped waiting. Letting that escape would abandon the steps that follow, which is how an
+ * experiment ends up one sample short with its controls stuck mid-run.
+ */
+const tryRequest = async <T,>(request: () => Promise<T>): Promise<T | undefined> => {
+  try {
+    return await request();
+  } catch (error) {
+    console.warn("Sampler: CODAP request did not complete:", error); // eslint-disable-line no-console
+    return undefined;
+  }
+};
+
 export const createExperimentAnimationSteps = (model: IModel, dataContextName: string, animationResults: IExperimentAnimationResults, results: IExperimentResults, onComplete?: () => void): Array<AnimationStep> => {
   const steps: AnimationStep[] = [];
   const finalSampleResults: ISampleResults[][] = [];
@@ -90,9 +107,12 @@ export const createExperimentAnimationSteps = (model: IModel, dataContextName: s
             // in fastest mode the samples are created at the end of the experiment
             finalSampleResults.push(sampleResults);
           } else {
-            const createItemsResult = await createItems(dataContextName, sampleResults) as any;
+            // As at the end of the experiment, a request that outlives the response deadline must
+            // not abort the animation — the remaining samples still need to be collected.
+            const createItemsResult =
+              await tryRequest(() => createItems(dataContextName, sampleResults)) as any;
             if (createItemsResult?.caseIDs) {
-              await selectCases(dataContextName, createItemsResult.caseIDs);
+              await tryRequest(() => selectCases(dataContextName, createItemsResult.caseIDs));
             }
           }
         }
@@ -102,27 +122,34 @@ export const createExperimentAnimationSteps = (model: IModel, dataContextName: s
   });
 
   steps.push({ kind: "endExperiment", onComplete: async () => {
-    // in fastest mode the samples are created at the end of the experiment
-    if (finalSampleResults.length > 0) {
-      // create all but the last set of samples in one shot
-      const lastSampleResults = finalSampleResults.pop();
+    // Each request is issued through tryRequest so that one that outlives the response deadline
+    // costs at most its own result: the last sample is still created, and the experiment still
+    // finishes. onComplete runs from a finally so the controls can never be left mid-run.
+    try {
+      // in fastest mode the samples are created at the end of the experiment
       if (finalSampleResults.length > 0) {
-        const mergedFinalSampleResults: ISampleResults[] = [];
-        for (const sampleResults of finalSampleResults) {
-          mergedFinalSampleResults.push(...sampleResults);
+        // create all but the last set of samples in one shot
+        const lastSampleResults = finalSampleResults.pop();
+        if (finalSampleResults.length > 0) {
+          const mergedFinalSampleResults: ISampleResults[] = [];
+          for (const sampleResults of finalSampleResults) {
+            mergedFinalSampleResults.push(...sampleResults);
+          }
+          await tryRequest(() => createItems(dataContextName, mergedFinalSampleResults));
         }
-        await createItems(dataContextName, mergedFinalSampleResults);
-      }
 
-      // create the last set of samples and select them
-      if (lastSampleResults) {
-        const createItemsResult = await createItems(dataContextName, lastSampleResults) as any;
-        if (createItemsResult?.caseIDs) {
-          await selectCases(dataContextName, createItemsResult.caseIDs);
+        // create the last set of samples and select them
+        if (lastSampleResults) {
+          const createItemsResult =
+            await tryRequest(() => createItems(dataContextName, lastSampleResults)) as any;
+          if (createItemsResult?.caseIDs) {
+            await tryRequest(() => selectCases(dataContextName, createItemsResult.caseIDs));
+          }
         }
       }
+    } finally {
+      onComplete?.();
     }
-    onComplete?.();
   }});
 
   return steps;
@@ -473,10 +500,6 @@ export const useAnimationContextValue = (): IAnimationContext => {
         enableNewRun();
       };
 
-      setGlobalState(draft => {
-        draft.isPaused = false;
-        draft.isRunning = true;
-      });
       const newAnimationSteps = createExperimentAnimationSteps(model, finalDataContextName, animationResults, results, onEndRun);
       startAnimation(newAnimationSteps);
     } catch (e) {

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -565,9 +565,18 @@ export const useAnimationContextValue = (): IAnimationContext => {
       const newAnimationSteps = createExperimentAnimationSteps(model, finalDataContextName, animationResults, results, onEndRun);
       startAnimation(newAnimationSteps);
       // startAnimation runs whatever it is given, so a pause requested during the setup has to be
-      // re-applied to the animation it just replaced.
+      // re-applied to the animation it just replaced — unless the run has reached the fastest
+      // speed in the meantime, where it runs in one pass that no pause can reach. Carrying the
+      // pause over there would leave the controls offering to resume a run already under way.
       if (isPausedRef.current) {
-        togglePauseAnimation(true);
+        if (speedRef.current === Speed.Fastest) {
+          isPausedRef.current = false;
+          setGlobalState(draft => {
+            draft.isPaused = false;
+          });
+        } else {
+          togglePauseAnimation(true);
+        }
       }
     } catch (e) {
       if (!isCurrentRun()) {

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -133,6 +133,13 @@ export const createExperimentAnimationSteps = (model: IModel, dataContextName: s
           mergedFinalSampleResults.push(...sampleResults);
         }
 
+        // A sample can be animated without producing any rows — a device with no variables
+        // collects nothing — and creating no items succeeds without adding anything. There is
+        // then no sample just collected, so there is nothing to select and nothing to scroll to.
+        if (mergedFinalSampleResults.length === 0) {
+          return;
+        }
+
         // The whole experiment goes over in one request. CODAP prices a create by the size of the
         // dataset it is added to rather than by the number of items sent, so each additional
         // request costs about as much as the first however little it carries.

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -216,6 +216,8 @@ export interface IAnimationContext {
   handleStartRun: () => Promise<void>
   handleTogglePauseRun: (pause: boolean) => Promise<void>
   handleStopRun: () => Promise<void>
+  // whether the run under way is one that pause can no longer act on
+  isRunUninterruptible: () => boolean
   registerAnimationCallback: RegisterAnimationCallbackFn
 }
 


### PR DESCRIPTION
## Summary

At the fastest speed the samples are created at the end of the experiment rather than as they are collected. That was two requests: the bulk of the experiment, then the final sample peeled off on its own so its case ids could be selected and the table scrolled to it.

On a large experiment either can take far longer than the plugin API's response deadline — 11s for 3,600 items in Safari, measured — while CODAP goes on processing it successfully. The rejection escaped unhandled from `endExperiment`, so whatever followed never ran. If the bulk request was the one that timed out, the final sample was never sent: **99 samples instead of 100**. If it was the second, the data was complete but `selectCases` and `onComplete()` never fired. Either way the controls were left **stuck on Pause**.

Fixes SAMPLER-107.

The root cause is addressed in `codap-plugin-api` (concord-consortium/codap-plugin-api#14, merged), which no longer treats iframe-phone's advisory 2s timer as a request failure. This PR is the Sampler half: the plugin should not be left stranded by a request it stopped waiting for, whatever the library does.

## Changes

- **Requests no longer abandon the run.** They go through a `tryRequest` helper that reports a failure rather than propagating it, so a slow request costs at most its own result. `onComplete()` runs from a `finally`, so the experiment always reports itself finished and the controls can't strand. The per-sample path used at slower speeds gets the same treatment.
- **The controls show the run immediately.** `isRunning` was set only after the data context was set up and every sample collected — many round-trips to CODAP — so pressing Start appeared to do nothing for seconds. It is now set before the first request, and reset if setup fails. That puts Stop and Pause within reach of a run that has nothing to animate yet, so they act on it in the only way they can: the run carries an id, and one that has been stopped — or superseded by another Start — abandons itself rather than animating and writing an experiment nobody is waiting for. A pause requested during the setup is carried over to the animation the run goes on to build, instead of being lost when that animation replaces the paused one.
- **Pause is disabled at the fastest speed**, where the experiment completes in a single uninterruptible pass and pause has nothing to act on. Clicking it previously relabelled the control to Start while the run carried on. It stays disabled once the run is in that pass, since the pass ignores the speed from then on and lowering the slider part-way through would otherwise re-enable a control that could no longer reach the run. Stop still applies and remains enabled.
- **The two end-of-experiment requests become one** (`perf`). CODAP prices a create by the size of the dataset it is added to rather than by the number of items sent, so peeling off the final sample cost nearly as much as sending the rest of the experiment. The sample collection's last case — the one just collected — is read back and selected instead, which preserves both the selection and the table scrolling to it and cascading to its children. That selection is made only once the create is known to have landed: CODAP answers a create it refuses with `success: false` rather than rejecting, so the response is checked, since otherwise the last case could belong to an earlier experiment and selecting it would claim it is the sample just collected. Measured over a 100-sample experiment: **~19% less end-of-experiment work per item**, with full-dataset revalidations dropping from 12 to 7 and formula recalculations from 10 to 5. It also halves the number of requests that can outlive the deadline in the first place.
- **Setting up a run no longer abandons it.** `findOrCreateDataContext` sends more requests than anything else a run does, before a single sample is collected, so it is the likeliest place for one to outlive the deadline — and it awaited two that reject outright: the batched attribute-id get and the case-table create. Neither is worth an experiment (the ids are a cache; the table is already open on a repeat run), so both now report a failure and carry on. A run that does fail to start says so legibly: its own failures carry a message written for the user, and anything else goes to the console with a plain message in its place.
- **A request that CODAP never answers is handled.** The plugin API reports one by passing `undefined` to the callback and rejecting the promise. `updateAttributeIds` typed its batched callback as `(getAttrsResult: any[])` and called `.forEach` on it, so an unanswered request threw a `TypeError`; it now takes `(getAttrsResult?: IResult[])` and reads the ids only from a response that is the array of per-request results it is meant to be, which covers an unanswered request and a single error for the whole batch alike. `device.tsx` and `device-footer.tsx` issue requests they don't await, which now report a failure instead of leaking an unhandled rejection; `device.tsx`'s attribute creates are awaited rather than issued from a `forEach`, which would drop them before that failure could be reported — each on its own, so that one create CODAP doesn't answer costs no more than its own attribute and the attribute deletes that follow it still run.
- **A measure that was not added says so.** `addMeasure` chained three fire-and-forget requests off a `.then`, so a failure anywhere in the sequence surfaced as an unhandled rejection. It now awaits each step and reports whether the measure reached the table, refusals included. The measures panel awaits that answer: on a failure it says the measure could not be added and keeps what the user entered, rather than announcing success and clearing the form over a column that never appeared. The message lives in a live region so it is announced, the timer that clears a success message no longer wipes a later failure, and a second Add is refused while one is in flight, since two overlapping adds would compute the same attribute name and have the second refused as a duplicate, reporting a failure for a measure that was in fact added. The refusal is in the handler and the button is `aria-disabled` rather than `disabled` for the duration: taking the control the user has just activated out of the tab order drops a keyboard or screen reader user to the top of the document and does not bring them back — on the one path this state exists to serve, where they have to notice the failure and try again.

- **The selection is skipped for an experiment that collected no rows.** A sample can be animated without producing a row — a device with no variables collects nothing — and creating no items succeeds, which would otherwise be taken as licence to select the sample collection's last case, from an earlier experiment.
- **Only the run still under way acts.** The run id that lets a superseded run abandon itself now guards everything a run does after a request it may not outlive. The callback the animation steps hold on to, so a stopped run whose last create finally settles cannot hand the controls back over the run that replaced it. Both selection points, so it cannot move the case table's selection and scroll to its own last sample while the replacement is still collecting. And the fastest pass itself, which re-read the current runtime each time round its loop: a step still awaiting CODAP when the user pressed Start again resumed into the replacement, advancing *its* step index — skipping whichever step that landed on, and with it the samples of a `pushVariables` — before announcing an end of experiment over a run still under way. The pass now walks the runtime it started on.

## Dependency

`@concord-consortium/codap-plugin-api` is bumped to `^0.2.0`, published from concord-consortium/codap-plugin-api#14. That release is the root cause fix: it no longer treats iframe-phone's advisory 2s timer as a request failure, so a request CODAP is still working on is no longer reported as one that failed. It also drops `fork-ts-checker-webpack-plugin`, a build tool it had been shipping as a runtime dependency, which is why the lockfile loses about three hundred lines it never needed.

The Sampler's own failure handling is not contingent on that release and was written not to be — the plugin should not be stranded by a request it stopped waiting for, whatever the library does. It was green against 0.1.6 throughout the library's review, where iframe-phone's 2000 ms timer made every new `tryRequest` and `catch` path reachable.

## Testing

The behaviour above is pinned by tests in the `useAnimation`, run-state, `model-header` and `codap-helpers` suites — roughly fifty added here, covering the abandoned-run guards, the zero-row selection, the one-request end of experiment, the unanswered-request handling and the measure failure path. Each was confirmed to fail with its fix reverted: both run-id guards in the setup are pinned separately, since a test for either one alone passed on the other's back, and the superseded fastest pass has a test that hangs a create, stops and restarts the run, then releases it and asserts the replacement is neither stepped nor ended. Weakening the attribute-id guard fails the build rather than a test, the callback's type having been made honest about the non-array case. The changes without a unit test are the attribute creates in `device.tsx` and `findOrCreateDataContext`, neither of which has a harness to hang one on.

`tsc`, `npm run lint`, `npm run lint:build` and `npm run build` are clean, the last apart from a pre-existing warning in `cypress/e2e/workspace.test.ts`.

The `addMeasure` tests were additionally cross-checked against the previous implementation: its six behavioural tests pass unchanged there, confirming the rewrite preserved behaviour, while the failure-handling tests fail against it.

Verified end-to-end in Safari against a local CODAP and the published 0.2.0 plugin API, reproducing the original failure — unhandled rejection, 99 samples, stuck Pause — and confirming it no longer occurs across repeated 100-sample runs, with selection and table scrolling intact.

