### PR TITLE
fix: apply a column rename to the CODAP attribute [SAMPLER-106]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
+  // stop the cascade here so a config above the project (e.g. when this checkout is a git worktree
+  // nested inside another checkout) can't be merged in and conflict with this one
+  root: true,
   parser: "@typescript-eslint/parser",
   parserOptions: {
     ecmaVersion: 2018,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
-  // stop the cascade here so a config above the project (e.g. when this checkout is a git worktree
-  // nested inside another checkout) can't be merged in and conflict with this one
+  // this is the project's root config, so stop the cascade here rather than merging in whatever
+  // config happens to sit above the checkout
   root: true,
   parser: "@typescript-eslint/parser",
   parserOptions: {

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/src/components/model/column-header.test.tsx
+++ b/src/components/model/column-header.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { getAttribute, getCollectionList, updateAttribute } from "@concord-consortium/codap-plugin-api";
+import { ColumnHeader } from "./column-header";
+import { GlobalStateContext, getDefaultState } from "../../hooks/useGlobalState";
+import { IGlobalState } from "../../types";
+
+jest.mock("@concord-consortium/codap-plugin-api", () => ({
+  codapInterface: {
+    sendRequest: jest.fn().mockResolvedValue({ success: true, values: {} }),
+    updateInteractiveState: jest.fn(),
+    on: jest.fn()
+  },
+  addDataContextChangeListener: jest.fn(),
+  createChildCollection: jest.fn(),
+  createDataContext: jest.fn(),
+  createNewAttribute: jest.fn(),
+  createParentCollection: jest.fn(),
+  getAllItems: jest.fn(),
+  getAttribute: jest.fn(),
+  getAttributeList: jest.fn(),
+  getCaseCount: jest.fn(),
+  getCollectionList: jest.fn(),
+  getDataContext: jest.fn(),
+  getListOfDataContexts: jest.fn(),
+  initializePlugin: jest.fn(),
+  updateAttribute: jest.fn()
+}));
+
+// Stand in for a non-English locale, where the items collection is not named "items". Only the
+// collection name matters here, so every other string resolves to its own id.
+const itemsCollectionName = "objekter";
+jest.mock("../../utils/localeManager", () => ({
+  tr: (key: string) => key === "DG.Plugin.Sampler.dataset.item-collection-name" ? "objekter" : key
+}));
+
+const mockGetAttribute = getAttribute as jest.Mock;
+const mockGetCollectionList = getCollectionList as jest.Mock;
+const mockUpdateAttribute = updateAttribute as jest.Mock;
+
+const dataContextName = "Sampler";
+const oldName = "output";
+const newName = "choice";
+
+const renderColumnHeader = () => {
+  const globalState: IGlobalState = getDefaultState();
+  const column = globalState.model.columns[0];
+  column.name = oldName;
+  globalState.dataContextName = dataContextName;
+  globalState.attrMap = {
+    ...globalState.attrMap,
+    [column.id]: { codapID: "id-output", name: oldName }
+  };
+
+  render(
+    <GlobalStateContext.Provider value={{ globalState, setGlobalState: jest.fn() }}>
+      <ColumnHeader column={column} columnIndex={0} />
+    </GlobalStateContext.Provider>
+  );
+
+  return { column };
+};
+
+describe("ColumnHeader", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAttribute.mockResolvedValue({ success: true, values: { id: "id-output", name: oldName } });
+    mockUpdateAttribute.mockResolvedValue({ success: true });
+    // no collections to walk, so renaming the attribute in formulas is a no-op here
+    mockGetCollectionList.mockResolvedValue({ success: false });
+  });
+
+  // Renaming a column has to reach CODAP. When it doesn't, the case table keeps the old attribute
+  // and running the experiment adds the new one alongside it [SAMPLER-106].
+  it("renames the CODAP attribute when the column is renamed", async () => {
+    renderColumnHeader();
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: newName } });
+    fireEvent.blur(screen.getByRole("textbox"));
+
+    await waitFor(() => expect(mockUpdateAttribute).toHaveBeenCalledTimes(1));
+    expect(mockUpdateAttribute).toHaveBeenCalledWith(
+      dataContextName, itemsCollectionName, oldName, expect.anything(), { name: newName }
+    );
+  });
+});

--- a/src/components/model/column-header.test.tsx
+++ b/src/components/model/column-header.test.tsx
@@ -93,4 +93,30 @@ describe("ColumnHeader", () => {
     await waitFor(() => expect(mockUpdateAttribute).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(oldName));
   });
+
+  // A request that times out or meets a closed connection rejects rather than reporting failure, so
+  // the answer has to be the same as a refusal or the column and its attribute drift apart anyway.
+  it("keeps the old name when the rename request never answers", async () => {
+    mockUpdateAttribute.mockRejectedValue(new Error("connection closed"));
+    renderColumnHeader();
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: newName } });
+    fireEvent.blur(screen.getByRole("textbox"));
+
+    await waitFor(() => expect(mockUpdateAttribute).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(oldName));
+  });
+
+  // The attribute may be gone -- deleted in the case table -- in which case there is nothing to
+  // rename and carrying on would leave the column naming an attribute that does not exist.
+  it("keeps the old name when the attribute is no longer in CODAP", async () => {
+    mockGetAttribute.mockResolvedValue({ success: false });
+    renderColumnHeader();
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: newName } });
+    fireEvent.blur(screen.getByRole("textbox"));
+
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(oldName));
+    expect(mockUpdateAttribute).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/model/column-header.test.tsx
+++ b/src/components/model/column-header.test.tsx
@@ -44,14 +44,14 @@ const dataContextName = "Sampler";
 const oldName = "output";
 const newName = "choice";
 
-const stateWithColumn = () => {
+const stateWithColumn = ({ withAttrMapEntry = true } = {}) => {
   const globalState: IGlobalState = getDefaultState();
   const column = globalState.model.columns[0];
   column.name = oldName;
   globalState.dataContextName = dataContextName;
   globalState.attrMap = {
     ...globalState.attrMap,
-    [column.id]: { codapID: "id-output", name: oldName }
+    ...(withAttrMapEntry ? { [column.id]: { codapID: "id-output", name: oldName } } : {})
   };
   return { globalState, column };
 };
@@ -75,6 +75,21 @@ const renderWithStore = () => {
   return { column };
 };
 
+// Answers the way CODAP does: an attribute is found under the name it currently holds, and renaming
+// one it no longer holds fails. Enough to tell a second commit from the first.
+const fakeCodap = (initialName: string) => {
+  let heldName = initialName;
+  mockGetAttribute.mockImplementation(async (_ctx: string, _coll: string, name: string) =>
+    name === heldName ? { success: true, values: { name } } : { success: false });
+  mockUpdateAttribute.mockImplementation(
+    async (_ctx: string, _coll: string, name: string, _attr: unknown, values: { name: string }) => {
+      if (name !== heldName) return { success: false };
+      heldName = values.name;
+      return { success: true };
+    });
+  return { heldName: () => heldName };
+};
+
 const typeNewName = () => {
   const textbox = screen.getByRole("textbox");
   textbox.focus();
@@ -82,8 +97,8 @@ const typeNewName = () => {
   return textbox;
 };
 
-const renderColumnHeader = () => {
-  const { globalState, column } = stateWithColumn();
+const renderColumnHeader = (options?: { withAttrMapEntry?: boolean }) => {
+  const { globalState, column } = stateWithColumn(options);
   render(
     <GlobalStateContext.Provider value={{ globalState, setGlobalState: jest.fn() }}>
       <ColumnHeader column={column} columnIndex={0} />
@@ -155,6 +170,18 @@ describe("ColumnHeader", () => {
     expect(mockUpdateAttribute).not.toHaveBeenCalled();
   });
 
+  // The entry naming the attribute goes with the column, so an edit committed after the column is
+  // gone has nothing to rename from and must not go looking.
+  it("does not ask CODAP anything when the column's attrMap entry is already gone", async () => {
+    renderColumnHeader({ withAttrMapEntry: false });
+
+    fireEvent.blur(typeNewName());
+
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(oldName));
+    expect(mockGetAttribute).not.toHaveBeenCalled();
+    expect(mockUpdateAttribute).not.toHaveBeenCalled();
+  });
+
   // Blurring is what commits, and Enter blurs, so committing on Enter as well would run the whole
   // exchange a second time -- against a name CODAP has already renamed, which reads as a refusal and
   // puts the old name back.
@@ -166,6 +193,23 @@ describe("ColumnHeader", () => {
 
     await waitFor(() => expect(mockUpdateAttribute).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(newName));
+  });
+
+  // Leaving the field, returning to it and leaving again commits twice over. The second commit asks
+  // for a name the first has already renamed away, which reads as a refusal and puts the old name
+  // back -- the same undoing as committing on Enter, by a route Enter is not involved in.
+  it("does not undo itself when the field is left, returned to and left again", async () => {
+    const codap = fakeCodap(oldName);
+    renderColumnHeader();
+
+    const textbox = typeNewName();
+    fireEvent.blur(textbox);
+    textbox.focus();
+    fireEvent.blur(textbox);
+
+    await waitFor(() => expect(codap.heldName()).toBe(newName));
+    await act(async () => undefined);
+    expect(screen.getByRole("textbox")).toHaveValue(newName);
   });
 
   // Escape abandons the edit, and since blurring commits, cancelling has to reach the commit too.

--- a/src/components/model/column-header.test.tsx
+++ b/src/components/model/column-header.test.tsx
@@ -68,7 +68,7 @@ describe("ColumnHeader", () => {
   });
 
   // Renaming a column has to reach CODAP. When it doesn't, the case table keeps the old attribute
-  // and running the experiment adds the new one alongside it [SAMPLER-106].
+  // and running the experiment adds the new one alongside it.
   it("renames the CODAP attribute when the column is renamed", async () => {
     renderColumnHeader();
 
@@ -82,7 +82,7 @@ describe("ColumnHeader", () => {
   });
 
   // Carrying on with the new name when CODAP kept the old one is how the column and its attribute
-  // drift apart, which is what leaves a stale attribute behind on the next run [SAMPLER-106].
+  // drift apart, which is what leaves a stale attribute behind on the next run.
   it("keeps the old name when CODAP refuses the rename", async () => {
     mockUpdateAttribute.mockResolvedValue({ success: false });
     renderColumnHeader();

--- a/src/components/model/column-header.test.tsx
+++ b/src/components/model/column-header.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { getAttribute, getCollectionList, updateAttribute } from "@concord-consortium/codap-plugin-api";
+import { getAttribute, updateAttribute } from "@concord-consortium/codap-plugin-api";
 import { ColumnHeader } from "./column-header";
 import { GlobalStateContext, getDefaultState } from "../../hooks/useGlobalState";
 import { IGlobalState } from "../../types";
@@ -35,7 +35,6 @@ jest.mock("../../utils/localeManager", () => ({
 }));
 
 const mockGetAttribute = getAttribute as jest.Mock;
-const mockGetCollectionList = getCollectionList as jest.Mock;
 const mockUpdateAttribute = updateAttribute as jest.Mock;
 
 const dataContextName = "Sampler";
@@ -66,8 +65,6 @@ describe("ColumnHeader", () => {
     jest.clearAllMocks();
     mockGetAttribute.mockResolvedValue({ success: true, values: { id: "id-output", name: oldName } });
     mockUpdateAttribute.mockResolvedValue({ success: true });
-    // no collections to walk, so renaming the attribute in formulas is a no-op here
-    mockGetCollectionList.mockResolvedValue({ success: false });
   });
 
   // Renaming a column has to reach CODAP. When it doesn't, the case table keeps the old attribute

--- a/src/components/model/column-header.test.tsx
+++ b/src/components/model/column-header.test.tsx
@@ -80,4 +80,17 @@ describe("ColumnHeader", () => {
       dataContextName, itemsCollectionName, oldName, expect.anything(), { name: newName }
     );
   });
+
+  // Carrying on with the new name when CODAP kept the old one is how the column and its attribute
+  // drift apart, which is what leaves a stale attribute behind on the next run [SAMPLER-106].
+  it("keeps the old name when CODAP refuses the rename", async () => {
+    mockUpdateAttribute.mockResolvedValue({ success: false });
+    renderColumnHeader();
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: newName } });
+    fireEvent.blur(screen.getByRole("textbox"));
+
+    await waitFor(() => expect(mockUpdateAttribute).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(oldName));
+  });
 });

--- a/src/components/model/column-header.test.tsx
+++ b/src/components/model/column-header.test.tsx
@@ -1,9 +1,11 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { getAttribute, updateAttribute } from "@concord-consortium/codap-plugin-api";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useImmer } from "use-immer";
+import { getAttribute, getAttributeList, updateAttribute } from "@concord-consortium/codap-plugin-api";
 import { ColumnHeader } from "./column-header";
 import { GlobalStateContext, getDefaultState } from "../../hooks/useGlobalState";
-import { IGlobalState } from "../../types";
+import { createDefaultDevice } from "../../models/device-model";
+import { IGlobalState, IGlobalStateContext } from "../../types";
 
 jest.mock("@concord-consortium/codap-plugin-api", () => ({
   codapInterface: {
@@ -35,13 +37,14 @@ jest.mock("../../utils/localeManager", () => ({
 }));
 
 const mockGetAttribute = getAttribute as jest.Mock;
+const mockGetAttributeList = getAttributeList as jest.Mock;
 const mockUpdateAttribute = updateAttribute as jest.Mock;
 
 const dataContextName = "Sampler";
 const oldName = "output";
 const newName = "choice";
 
-const renderColumnHeader = () => {
+const stateWithColumn = () => {
   const globalState: IGlobalState = getDefaultState();
   const column = globalState.model.columns[0];
   column.name = oldName;
@@ -50,13 +53,42 @@ const renderColumnHeader = () => {
     ...globalState.attrMap,
     [column.id]: { codapID: "id-output", name: oldName }
   };
+  return { globalState, column };
+};
 
+// Some of what the commit does is only observable in the state it writes, so these render against a
+// real store rather than a stub updater, which would never run the recipe at all.
+let store: IGlobalStateContext;
+const StateProvider = ({ initialState, children }: { initialState: IGlobalState, children: React.ReactNode }) => {
+  const [globalState, setGlobalState] = useImmer<IGlobalState>(initialState);
+  store = { globalState, setGlobalState };
+  return <GlobalStateContext.Provider value={store}>{children}</GlobalStateContext.Provider>;
+};
+
+const renderWithStore = () => {
+  const { globalState, column } = stateWithColumn();
+  render(
+    <StateProvider initialState={globalState}>
+      <ColumnHeader column={column} columnIndex={0} />
+    </StateProvider>
+  );
+  return { column };
+};
+
+const typeNewName = () => {
+  const textbox = screen.getByRole("textbox");
+  textbox.focus();
+  fireEvent.change(textbox, { target: { value: newName } });
+  return textbox;
+};
+
+const renderColumnHeader = () => {
+  const { globalState, column } = stateWithColumn();
   render(
     <GlobalStateContext.Provider value={{ globalState, setGlobalState: jest.fn() }}>
       <ColumnHeader column={column} columnIndex={0} />
     </GlobalStateContext.Provider>
   );
-
   return { column };
 };
 
@@ -121,5 +153,97 @@ describe("ColumnHeader", () => {
 
     await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(oldName));
     expect(mockUpdateAttribute).not.toHaveBeenCalled();
+  });
+
+  // Blurring is what commits, and Enter blurs, so committing on Enter as well would run the whole
+  // exchange a second time -- against a name CODAP has already renamed, which reads as a refusal and
+  // puts the old name back.
+  it("commits once when the edit is finished with Enter", async () => {
+    renderColumnHeader();
+
+    const textbox = typeNewName();
+    fireEvent.keyDown(textbox, { code: "Enter" });
+
+    await waitFor(() => expect(mockUpdateAttribute).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(newName));
+  });
+
+  // Escape abandons the edit, and since blurring commits, cancelling has to reach the commit too.
+  it("does not rename anything when the edit is abandoned with Escape", async () => {
+    renderColumnHeader();
+
+    const textbox = typeNewName();
+    fireEvent.keyDown(textbox, { code: "Escape" });
+
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(oldName));
+    expect(mockUpdateAttribute).not.toHaveBeenCalled();
+  });
+
+  // A request that stops answering has not necessarily failed, so the name CODAP holds decides it.
+  it("takes the new name when CODAP turns out to hold it after all", async () => {
+    mockUpdateAttribute.mockRejectedValue(new Error("connection closed"));
+    mockGetAttributeList.mockResolvedValue({ success: true, values: [{ name: newName }] });
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    renderColumnHeader();
+
+    const textbox = typeNewName();
+    fireEvent.blur(textbox);
+
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(newName));
+    warn.mockRestore();
+  });
+
+  it("keeps the old name when CODAP turns out not to hold the new one", async () => {
+    mockUpdateAttribute.mockRejectedValue(new Error("connection closed"));
+    mockGetAttributeList.mockResolvedValue({ success: true, values: [{ name: oldName }] });
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    renderColumnHeader();
+
+    const textbox = typeNewName();
+    fireEvent.blur(textbox);
+
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(oldName));
+    warn.mockRestore();
+  });
+
+  // Deleting a column takes its attrMap entry with it, so a commit that outlives the entry it was
+  // opened on must not write through it. Writing through it throws inside the recipe, which escapes
+  // as far as the error boundary.
+  it("survives the column's attrMap entry being deleted while the rename is in flight", async () => {
+    let finishRename = (result: unknown) => { /* replaced below */ };
+    mockUpdateAttribute.mockImplementation(() => new Promise(resolve => { finishRename = resolve; }));
+    const { column } = renderWithStore();
+
+    fireEvent.blur(typeNewName());
+    await waitFor(() => expect(mockUpdateAttribute).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      store.setGlobalState(draft => { delete draft.attrMap[column.id]; });
+    });
+    await act(async () => { finishRename({ success: true }); });
+
+    expect(store.globalState.attrMap[column.id]).toBeUndefined();
+    expect(store.globalState.model.columns[0].name).toBe(newName);
+  });
+
+  // Columns are addressed by index everywhere else, but an index means something different once a
+  // column to the left is gone, and a commit can outlive that too.
+  it("renames the column it was opened on rather than whatever now sits at its index", async () => {
+    let finishRename = (result: unknown) => { /* replaced below */ };
+    mockUpdateAttribute.mockImplementation(() => new Promise(resolve => { finishRename = resolve; }));
+    renderWithStore();
+
+    fireEvent.blur(typeNewName());
+    await waitFor(() => expect(mockUpdateAttribute).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      store.setGlobalState(draft => {
+        draft.model.columns.unshift({ name: "first", id: "other-column", devices: [createDefaultDevice()] });
+      });
+    });
+    await act(async () => { finishRename({ success: true }); });
+
+    expect(store.globalState.model.columns[0].name).toBe("first");
+    expect(store.globalState.model.columns[1].name).toBe(newName);
   });
 });

--- a/src/components/model/column-header.test.tsx
+++ b/src/components/model/column-header.test.tsx
@@ -41,6 +41,7 @@ const mockGetAttributeList = getAttributeList as jest.Mock;
 const mockUpdateAttribute = updateAttribute as jest.Mock;
 
 const dataContextName = "Sampler";
+const attributeId = "id-output";
 const oldName = "output";
 const newName = "choice";
 
@@ -51,7 +52,7 @@ const stateWithColumn = ({ withAttrMapEntry = true } = {}) => {
   globalState.dataContextName = dataContextName;
   globalState.attrMap = {
     ...globalState.attrMap,
-    ...(withAttrMapEntry ? { [column.id]: { codapID: "id-output", name: oldName } } : {})
+    ...(withAttrMapEntry ? { [column.id]: { codapID: attributeId, name: oldName } } : {})
   };
   return { globalState, column };
 };
@@ -110,7 +111,7 @@ const renderColumnHeader = (options?: { withAttrMapEntry?: boolean }) => {
 describe("ColumnHeader", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetAttribute.mockResolvedValue({ success: true, values: { id: "id-output", name: oldName } });
+    mockGetAttribute.mockResolvedValue({ success: true, values: { id: attributeId, name: oldName } });
     mockUpdateAttribute.mockResolvedValue({ success: true });
   });
 
@@ -138,7 +139,8 @@ describe("ColumnHeader", () => {
     fireEvent.blur(screen.getByRole("textbox"));
 
     await waitFor(() => expect(mockUpdateAttribute).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(oldName));
+    await waitFor(() => expect(screen.getByRole("textbox", { name: "Column name" })).toHaveValue(oldName));
+    expect(screen.getByRole("status")).toHaveTextContent(`Could not rename ${oldName}.`);
   });
 
   // A request that times out or meets a closed connection rejects rather than reporting failure, so
@@ -182,10 +184,10 @@ describe("ColumnHeader", () => {
     expect(mockUpdateAttribute).not.toHaveBeenCalled();
   });
 
-  // Blurring is what commits, and Enter blurs, so committing on Enter as well would run the whole
-  // exchange a second time -- against a name CODAP has already renamed, which reads as a refusal and
-  // puts the old name back.
-  it("commits once when the edit is finished with Enter", async () => {
+  // Finishing with Enter has to leave the name where the user put it. Enter blurs, and blurring is
+  // what commits, so the commit runs once from there. A second commit would be stood down by the
+  // same latch the leave-return-leave test pins, so this pins the outcome rather than that branch.
+  it("keeps the new name when the edit is finished with Enter", async () => {
     renderColumnHeader();
 
     const textbox = typeNewName();
@@ -212,6 +214,24 @@ describe("ColumnHeader", () => {
     expect(screen.getByRole("textbox")).toHaveValue(newName);
   });
 
+  // A commit stands down while one is under way. The edit typed in the meantime is not made, so the
+  // field goes back to the name that is actually being committed and says why.
+  it("says so rather than silently dropping an edit made while a commit is in flight", async () => {
+    const codap = fakeCodap(oldName);
+    renderWithStore();
+
+    const textbox = typeNewName();
+    fireEvent.blur(textbox);
+    textbox.focus();
+    fireEvent.change(textbox, { target: { value: "pick" } });
+    fireEvent.blur(textbox);
+
+    await waitFor(() => expect(codap.heldName()).toBe(newName));
+    await act(async () => undefined);
+    expect(screen.getByRole("status")).toHaveTextContent(`Still renaming to ${newName}.`);
+    expect(screen.getByRole("textbox")).toHaveValue(newName);
+  });
+
   // Escape abandons the edit, and since blurring commits, cancelling has to reach the commit too.
   it("does not rename anything when the edit is abandoned with Escape", async () => {
     renderColumnHeader();
@@ -223,30 +243,53 @@ describe("ColumnHeader", () => {
     expect(mockUpdateAttribute).not.toHaveBeenCalled();
   });
 
-  // A request that stops answering has not necessarily failed, so the name CODAP holds decides it.
-  it("takes the new name when CODAP turns out to hold it after all", async () => {
+  // A request that stops answering has not necessarily failed, so what became of the attribute
+  // decides it. The header already shows the typed name, so only the store settles whether the
+  // rename was adopted.
+  it("takes the new name when CODAP turns out to have renamed the attribute after all", async () => {
     mockUpdateAttribute.mockRejectedValue(new Error("connection closed"));
-    mockGetAttributeList.mockResolvedValue({ success: true, values: [{ name: newName }] });
+    mockGetAttributeList.mockResolvedValue({ success: true, values: [{ id: attributeId, name: newName }] });
     const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
-    renderColumnHeader();
+    const { column } = renderWithStore();
 
-    const textbox = typeNewName();
-    fireEvent.blur(textbox);
+    fireEvent.blur(typeNewName());
 
-    await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(newName));
+    await waitFor(() => expect(store.globalState.model.columns[0].name).toBe(newName));
+    expect(store.globalState.attrMap[column.id].name).toBe(newName);
+    expect(mockGetAttributeList).toHaveBeenCalled();
     warn.mockRestore();
   });
 
-  it("keeps the old name when CODAP turns out not to hold the new one", async () => {
+  it("keeps the old name when the attribute turns out still to carry it", async () => {
     mockUpdateAttribute.mockRejectedValue(new Error("connection closed"));
-    mockGetAttributeList.mockResolvedValue({ success: true, values: [{ name: oldName }] });
+    mockGetAttributeList.mockResolvedValue({ success: true, values: [{ id: attributeId, name: oldName }] });
     const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
-    renderColumnHeader();
+    const { column } = renderWithStore();
 
-    const textbox = typeNewName();
-    fireEvent.blur(textbox);
+    fireEvent.blur(typeNewName());
 
     await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(oldName));
+    expect(store.globalState.model.columns[0].name).toBe(oldName);
+    expect(store.globalState.attrMap[column.id].name).toBe(oldName);
+    warn.mockRestore();
+  });
+
+  // Deleting a column leaves an attribute that holds data behind, so something else can already
+  // answer to the new name. Only this column's attribute having taken it counts as a rename.
+  it("keeps the old name when the new name belongs to some other attribute", async () => {
+    mockUpdateAttribute.mockRejectedValue(new Error("connection closed"));
+    mockGetAttributeList.mockResolvedValue({ success: true, values: [
+      { id: attributeId, name: oldName },
+      { id: "id-orphan", name: newName }
+    ] });
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { column } = renderWithStore();
+
+    fireEvent.blur(typeNewName());
+
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(oldName));
+    expect(store.globalState.model.columns[0].name).toBe(oldName);
+    expect(store.globalState.attrMap[column.id].name).toBe(oldName);
     warn.mockRestore();
   });
 

--- a/src/components/model/column-header.tsx
+++ b/src/components/model/column-header.tsx
@@ -12,13 +12,24 @@ interface IProps {
   columnIndex: number;
 }
 
-// Asks CODAP which name it holds, for when a rename stopped answering rather than reported an
-// outcome. Reads as not renamed when the question itself cannot be answered.
-const codapHoldsName = async (dataContextName: string, collectionName: string, name: string) => {
-  const attrList = await tryRequest(() => getAttributeList(dataContextName, collectionName),
-    `could not read the attributes of ${collectionName}`);
-  return !!attrList?.success && attrList.values.some((attr: {name: string}) => attr.name === name);
-};
+// Asks whether the attribute a column stands for is the one now called newName, for when a rename
+// stopped answering rather than reported an outcome. The name alone would not settle it: deleting a
+// column leaves an attribute that holds data behind, so an attribute can outlive the column that
+// named it and a later column can ask for the same name. Reads as not renamed whenever the question
+// cannot be answered, which includes not knowing the attribute's id.
+const codapRenamedAttribute =
+  async (dataContextName: string, collectionName: string, codapID: string | null, newName: string) => {
+    if (!codapID) {
+      return false;
+    }
+    const attrList = await tryRequest(() => getAttributeList(dataContextName, collectionName),
+      `could not read the attributes of ${collectionName}`);
+    if (!attrList?.success || !Array.isArray(attrList.values)) {
+      return false;
+    }
+    return attrList.values.some((attr: {id: string | number, name: string}) =>
+      attr.name === newName && String(attr.id) === String(codapID));
+  };
 
 export const ColumnHeader = ({column, columnIndex}: IProps) => {
   const { globalState, setGlobalState } = useGlobalStateContext();
@@ -28,6 +39,8 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const cancelEditRef = useRef(false);
   const committingRef = useRef(false);
+  const typedNameRef = useRef(column.name);
+  const committingNameRef = useRef(column.name);
   const [label, setLabel] = useState("");
   const [message, setMessage] = useState("");
   const [opacity, setOpacity] = useState(0);
@@ -51,6 +64,7 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
   }, []);
 
   useEffect(() => {
+    typedNameRef.current = column.name;
     setColumnName(column.name);
   }, [column.name]);
 
@@ -69,6 +83,9 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
     return model.columns[columnIndex].devices[0].viewType === "collector";
   }, [model, columnIndex]);
 
+  // The strings this writes, and the field's label below, are English rather than tr() keys, for the
+  // reason given at the TODO in components/measures/measures.tsx: tr() renders the key itself when a
+  // string is missing, so the POEditor entries have to exist before the keys can be used.
   const handleNameChange = async () => {
     // Escape restores the name and then blurs, and blurring is what commits, so the commit has to
     // know to stand down.
@@ -77,25 +94,44 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
       return;
     }
 
-    // Leaving the field, returning to it and leaving again commits twice over. The second commit
-    // would ask CODAP for a name the first has already renamed away and read that as a refusal.
+    // Leaving the field, returning to it and leaving again commits twice over, and the second commit
+    // would ask CODAP for a name the first has already renamed away and read that as a refusal. The
+    // field goes back to the name actually on its way to CODAP, so that it says what is happening
+    // rather than showing an edit that is not being made.
     if (committingRef.current) {
+      typedNameRef.current = committingNameRef.current;
+      setColumnName(committingNameRef.current);
+      setMessage(`Still renaming to ${committingNameRef.current}.`);
       return;
     }
 
-    const newName = getNewColumnName(columnName.trim(), model.columns, column.id);
+    const typedName = typedNameRef.current.trim();
+    const newName = getNewColumnName(typedName, model.columns, column.id);
 
     // do not allow the user to clear the input and leave it empty
     if (newName.length === 0) {
       setColumnName(column.name);
+      setMessage("A column needs a name.");
       return;
     }
 
-    const keepOldName = () => {
+    if (newName === column.name) {
+      // nothing to rename. Saying so anyway would write to the document, and put an entry on CODAP's
+      // undo stack, every time the field is tabbed through
+      return;
+    }
+
+    if (newName !== typedName) {
+      setMessage(`Another column is called ${typedName}, so this one is ${newName}.`);
+    }
+
+    const keepOldName = (reason: string) => {
+      console.warn(`Sampler: ${reason}`);
       setColumnName(column.name);
       setMessage(`Could not rename ${column.name}.`);
     };
 
+    committingNameRef.current = newName;
     committingRef.current = true;
     try {
       await commitNameChange(newName, keepOldName);
@@ -104,7 +140,7 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
     }
   };
 
-  const commitNameChange = async (newName: string, keepOldName: () => void) => {
+  const commitNameChange = async (newName: string, keepOldName: (reason: string) => void) => {
     // Renaming the column while CODAP still knows the attribute by its old name is what leaves the
     // stale attribute behind on the next run, so the column keeps its old name unless CODAP renamed
     // the attribute.
@@ -121,7 +157,7 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
             `could not look up the attribute named ${oldAttrName}`)
         : undefined;
       if (!attrResult?.success) {
-        keepOldName();
+        keepOldName(`there is no attribute named ${oldAttrName} to rename`);
         return;
       }
       const renameResult = await tryRequest(
@@ -129,19 +165,19 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
         `could not rename the attribute ${oldAttrName}`);
       // No answer means only that we stopped waiting -- CODAP may have renamed the attribute anyway.
       // Keeping the old name and taking the new one both risk the column and the attribute
-      // disagreeing, so ask CODAP which name it holds rather than picking one.
+      // disagreeing, so ask CODAP what became of this attribute rather than picking one.
       const renamed = renameResult
         ? renameResult.success
-        : await codapHoldsName(dataContextName, itemsCollectionName, newName);
+        : await codapRenamedAttribute(
+            dataContextName, itemsCollectionName, globalState.attrMap[column.id]?.codapID ?? null, newName);
       if (!renamed) {
-        keepOldName();
+        keepOldName(`CODAP did not rename ${oldAttrName} to ${newName}`);
         return;
       }
     }
 
     // CODAP keeps formulas that reference the attribute correct on its own -- it stores them against
     // attribute ids and regenerates the displayed text -- so renaming it is all there is to do here
-    setMessage("");
     setColumnName(newName);
     setGlobalState(draft => {
       // a column can be deleted while the requests above are in flight, taking its attrMap entry
@@ -156,12 +192,24 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
     });
   };
 
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    typedNameRef.current = e.target.value;
+    setColumnName(e.target.value);
+    // the message described a name the field no longer holds, and clearing it means the next failure
+    // moves the region from empty to filled, which is what a screen reader announces
+    setMessage("");
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     switch(e.code) {
       case "Escape":
         cancelEditRef.current = true;
+        typedNameRef.current = column.name;
         setColumnName(column.name);
+        setMessage("");
+        // blur runs the commit synchronously, which clears the latch, so it cannot be left standing
         inputRef.current?.blur();
+        cancelEditRef.current = false;
         break;
       case "Enter":
         // blurring commits, so committing here as well would run the whole exchange twice
@@ -179,7 +227,7 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
         className="attr-name"
         aria-label="Column name"
         value={isCollectorOnlyModel(model) ? collectorContextName : columnName}
-        onChange={(e) => setColumnName(e.target.value)}
+        onChange={handleChange}
         onKeyDown={(e) => handleKeyDown(e)}
         onBlur={handleNameChange}
       >

--- a/src/components/model/column-header.tsx
+++ b/src/components/model/column-header.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useGlobalStateContext } from "../../hooks/useGlobalState";
-import { getAttribute, updateAttribute } from "@concord-consortium/codap-plugin-api";
+import { getAttribute, getAttributeList, updateAttribute } from "@concord-consortium/codap-plugin-api";
 import { getNewColumnName } from "../helpers";
 import { useAnimationContext } from "../../hooks/useAnimation";
 import { AnimationStep, IAnimationStepSettings, IColumn } from "../../types";
@@ -12,13 +12,23 @@ interface IProps {
   columnIndex: number;
 }
 
+// Asks CODAP which name it holds, for when a rename stopped answering rather than reported an
+// outcome. Reads as not renamed when the question itself cannot be answered.
+const codapHoldsName = async (dataContextName: string, collectionName: string, name: string) => {
+  const attrList = await tryRequest(() => getAttributeList(dataContextName, collectionName),
+    `could not read the attributes of ${collectionName}`);
+  return !!attrList?.success && attrList.values.some((attr: {name: string}) => attr.name === name);
+};
+
 export const ColumnHeader = ({column, columnIndex}: IProps) => {
   const { globalState, setGlobalState } = useGlobalStateContext();
   const { registerAnimationCallback } = useAnimationContext();
   const { model, isRunning, collectorContextName } = globalState;
   const [columnName, setColumnName] = useState(column.name);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const cancelEditRef = useRef(false);
   const [label, setLabel] = useState("");
+  const [message, setMessage] = useState("");
   const [opacity, setOpacity] = useState(0);
 
   const animate = (step: AnimationStep, settings?: IAnimationStepSettings) => {
@@ -59,6 +69,13 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
   }, [model, columnIndex]);
 
   const handleNameChange = async () => {
+    // Escape restores the name and then blurs, and blurring is what commits, so the commit has to
+    // know to stand down.
+    if (cancelEditRef.current) {
+      cancelEditRef.current = false;
+      return;
+    }
+
     const newName = getNewColumnName(columnName.trim(), model.columns, column.id);
 
     // do not allow the user to clear the input and leave it empty
@@ -67,10 +84,14 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
       return;
     }
 
+    const keepOldName = () => {
+      setColumnName(column.name);
+      setMessage(`Could not rename ${column.name}.`);
+    };
+
     // Renaming the column while CODAP still knows the attribute by its old name is what leaves the
     // stale attribute behind on the next run, so the column keeps its old name unless CODAP renamed
-    // the attribute. A request can also reject rather than report failure -- it does so on a timeout
-    // and on a closed connection -- which has to mean the same thing here.
+    // the attribute.
     if (globalState.dataContextName) {
       const { dataContextName } = globalState;
       const itemsCollectionName = getCollectionNames().items;
@@ -84,42 +105,51 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
             `could not look up the attribute named ${oldAttrName}`)
         : undefined;
       if (!attrResult?.success) {
-        setColumnName(column.name);
+        keepOldName();
         return;
       }
       const renameResult = await tryRequest(
         () => updateAttribute(dataContextName, itemsCollectionName, oldAttrName, attrResult.values, {name: newName}),
         `could not rename the attribute ${oldAttrName}`);
-      if (!renameResult?.success) {
-        setColumnName(column.name);
+      // No answer means only that we stopped waiting -- CODAP may have renamed the attribute anyway.
+      // Keeping the old name and taking the new one both risk the column and the attribute
+      // disagreeing, so ask CODAP which name it holds rather than picking one.
+      const renamed = renameResult
+        ? renameResult.success
+        : await codapHoldsName(dataContextName, itemsCollectionName, newName);
+      if (!renamed) {
+        keepOldName();
         return;
       }
     }
 
-    // formulas that reference the attribute are CODAP's to update -- see the commented-out
-    // renameAttributeInFormulas in codap-helpers for why the plugin leaves them alone
+    // CODAP keeps formulas that reference the attribute correct on its own -- it stores them against
+    // attribute ids and regenerates the displayed text -- so renaming it is all there is to do here
+    setMessage("");
     setColumnName(newName);
     setGlobalState(draft => {
-      draft.model.columns[columnIndex].name = newName;
-      draft.attrMap[column.id].name = newName;
+      // a column can be deleted while the requests above are in flight, taking its attrMap entry
+      // with it, and columnIndex addresses a different column once one to its left is gone
+      const draftColumn = draft.model.columns.find(c => c.id === column.id);
+      if (draftColumn) {
+        draftColumn.name = newName;
+      }
+      if (draft.attrMap[column.id]) {
+        draft.attrMap[column.id].name = newName;
+      }
     });
   };
-
-  const resetInput = useCallback(() => {
-    if (inputRef.current) {
-      inputRef.current.value = columnName;
-    }
-  }, [columnName]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     switch(e.code) {
       case "Escape":
+        cancelEditRef.current = true;
+        setColumnName(column.name);
         inputRef.current?.blur();
-        resetInput();
         break;
       case "Enter":
+        // blurring commits, so committing here as well would run the whole exchange twice
         inputRef.current?.blur();
-        handleNameChange();
         break;
     }
   };
@@ -131,6 +161,7 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
         ref={inputRef}
         disabled={isRunning || isCollector}
         className="attr-name"
+        aria-label="Column name"
         value={isCollectorOnlyModel(model) ? collectorContextName : columnName}
         onChange={(e) => setColumnName(e.target.value)}
         onKeyDown={(e) => handleKeyDown(e)}
@@ -139,6 +170,9 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
       </textarea>
       <div className="device-column-header-label" style={{opacity}}>
         {label}
+      </div>
+      <div className="device-column-header-message" role="status" aria-live="polite">
+        {message}
       </div>
     </div>
   );

--- a/src/components/model/column-header.tsx
+++ b/src/components/model/column-header.tsx
@@ -74,15 +74,17 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
     if (globalState.dataContextName) {
       const { dataContextName } = globalState;
       const itemsCollectionName = getCollectionNames().items;
-      const oldAttrName = globalState.attrMap[column.id].name;
       try {
+        // deleting a column takes its attrMap entry with it, so this can be gone by the time a
+        // pending edit is committed
+        const oldAttrName = globalState.attrMap[column.id].name;
+        // updateAttribute renames by name and ignores the attribute it is handed, so this asks only
+        // whether there is still something to rename
         const attrResult = await getAttribute(dataContextName, itemsCollectionName, oldAttrName);
         if (!attrResult.success) {
           setColumnName(column.name);
           return;
         }
-        // updateAttribute ignores the attribute it is handed and renames by name, so this is only
-        // a check that there is still something to rename
         const renameResult =
           await updateAttribute(dataContextName, itemsCollectionName, oldAttrName, attrResult.values, {name: newName});
         if (!renameResult.success) {
@@ -90,6 +92,7 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
           return;
         }
       } catch (e) {
+        console.error(e);
         setColumnName(column.name);
         return;
       }

--- a/src/components/model/column-header.tsx
+++ b/src/components/model/column-header.tsx
@@ -4,7 +4,7 @@ import { getAttribute, updateAttribute } from "@concord-consortium/codap-plugin-
 import { getNewColumnName } from "../helpers";
 import { useAnimationContext } from "../../hooks/useAnimation";
 import { AnimationStep, IAnimationStepSettings, IColumn } from "../../types";
-import { renameAttributeInFormulas } from "../../helpers/codap-helpers";
+import { getCollectionNames, renameAttributeInFormulas } from "../../helpers/codap-helpers";
 import { isCollectorOnlyModel } from "../../utils/collector";
 
 interface IProps {
@@ -67,11 +67,12 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
       return;
     }
 
-    if (globalState.samplerContext) {
-      const dataContextName = globalState.samplerContext.name;
+    if (globalState.dataContextName) {
+      const { dataContextName } = globalState;
+      const itemsCollectionName = getCollectionNames().items;
       const oldAttrName = globalState.attrMap[column.id].name;
-      const attr = (await getAttribute(dataContextName, "items", oldAttrName)).values;
-      await updateAttribute(dataContextName, "items", oldAttrName, attr, {name: newName});
+      const attr = (await getAttribute(dataContextName, itemsCollectionName, oldAttrName)).values;
+      await updateAttribute(dataContextName, itemsCollectionName, oldAttrName, attr, {name: newName});
       await renameAttributeInFormulas(dataContextName, oldAttrName, newName);
       setColumnName(newName);
       setGlobalState(draft => {

--- a/src/components/model/column-header.tsx
+++ b/src/components/model/column-header.tsx
@@ -67,31 +67,41 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
       return;
     }
 
+    // Renaming the column while CODAP still knows the attribute by its old name is what leaves the
+    // stale attribute behind on the next run, so the column keeps its old name unless CODAP renamed
+    // the attribute. A request can also reject rather than report failure -- it does so on a timeout
+    // and on a closed connection -- which has to mean the same thing here.
     if (globalState.dataContextName) {
       const { dataContextName } = globalState;
       const itemsCollectionName = getCollectionNames().items;
       const oldAttrName = globalState.attrMap[column.id].name;
-      const attr = (await getAttribute(dataContextName, itemsCollectionName, oldAttrName)).values;
-      const renameResult = await updateAttribute(dataContextName, itemsCollectionName, oldAttrName, attr, {name: newName});
-      if (!renameResult.success) {
-        // renaming the column anyway would leave it naming an attribute that no longer answers to it,
-        // and the next run would add the new name alongside the old one
+      try {
+        const attrResult = await getAttribute(dataContextName, itemsCollectionName, oldAttrName);
+        if (!attrResult.success) {
+          setColumnName(column.name);
+          return;
+        }
+        // updateAttribute ignores the attribute it is handed and renames by name, so this is only
+        // a check that there is still something to rename
+        const renameResult =
+          await updateAttribute(dataContextName, itemsCollectionName, oldAttrName, attrResult.values, {name: newName});
+        if (!renameResult.success) {
+          setColumnName(column.name);
+          return;
+        }
+      } catch (e) {
         setColumnName(column.name);
         return;
       }
-      // formulas that reference the attribute are CODAP's to update -- see renameAttributeInFormulas
-      setColumnName(newName);
-      setGlobalState(draft => {
-        draft.model.columns[columnIndex].name = newName;
-        draft.attrMap[column.id].name = newName;
-      });
-    } else {
-      setColumnName(newName);
-      setGlobalState(draft => {
-        draft.model.columns[columnIndex].name = newName;
-        draft.attrMap[column.id].name = newName;
-      });
     }
+
+    // formulas that reference the attribute are CODAP's to update -- see the commented-out
+    // renameAttributeInFormulas in codap-helpers for why the plugin no longer rewrites them
+    setColumnName(newName);
+    setGlobalState(draft => {
+      draft.model.columns[columnIndex].name = newName;
+      draft.attrMap[column.id].name = newName;
+    });
   };
 
   const resetInput = useCallback(() => {

--- a/src/components/model/column-header.tsx
+++ b/src/components/model/column-header.tsx
@@ -97,7 +97,7 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
     }
 
     // formulas that reference the attribute are CODAP's to update -- see the commented-out
-    // renameAttributeInFormulas in codap-helpers for why the plugin no longer rewrites them
+    // renameAttributeInFormulas in codap-helpers for why the plugin leaves them alone
     setColumnName(newName);
     setGlobalState(draft => {
       draft.model.columns[columnIndex].name = newName;

--- a/src/components/model/column-header.tsx
+++ b/src/components/model/column-header.tsx
@@ -72,7 +72,13 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
       const itemsCollectionName = getCollectionNames().items;
       const oldAttrName = globalState.attrMap[column.id].name;
       const attr = (await getAttribute(dataContextName, itemsCollectionName, oldAttrName)).values;
-      await updateAttribute(dataContextName, itemsCollectionName, oldAttrName, attr, {name: newName});
+      const renameResult = await updateAttribute(dataContextName, itemsCollectionName, oldAttrName, attr, {name: newName});
+      if (!renameResult.success) {
+        // renaming the column anyway would leave it naming an attribute that no longer answers to it,
+        // and the next run would add the new name alongside the old one
+        setColumnName(column.name);
+        return;
+      }
       // formulas that reference the attribute are CODAP's to update -- see renameAttributeInFormulas
       setColumnName(newName);
       setGlobalState(draft => {

--- a/src/components/model/column-header.tsx
+++ b/src/components/model/column-header.tsx
@@ -27,6 +27,7 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
   const [columnName, setColumnName] = useState(column.name);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const cancelEditRef = useRef(false);
+  const committingRef = useRef(false);
   const [label, setLabel] = useState("");
   const [message, setMessage] = useState("");
   const [opacity, setOpacity] = useState(0);
@@ -76,6 +77,12 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
       return;
     }
 
+    // Leaving the field, returning to it and leaving again commits twice over. The second commit
+    // would ask CODAP for a name the first has already renamed away and read that as a refusal.
+    if (committingRef.current) {
+      return;
+    }
+
     const newName = getNewColumnName(columnName.trim(), model.columns, column.id);
 
     // do not allow the user to clear the input and leave it empty
@@ -89,6 +96,15 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
       setMessage(`Could not rename ${column.name}.`);
     };
 
+    committingRef.current = true;
+    try {
+      await commitNameChange(newName, keepOldName);
+    } finally {
+      committingRef.current = false;
+    }
+  };
+
+  const commitNameChange = async (newName: string, keepOldName: () => void) => {
     // Renaming the column while CODAP still knows the attribute by its old name is what leaves the
     // stale attribute behind on the next run, so the column keeps its old name unless CODAP renamed
     // the attribute.

--- a/src/components/model/column-header.tsx
+++ b/src/components/model/column-header.tsx
@@ -4,7 +4,7 @@ import { getAttribute, updateAttribute } from "@concord-consortium/codap-plugin-
 import { getNewColumnName } from "../helpers";
 import { useAnimationContext } from "../../hooks/useAnimation";
 import { AnimationStep, IAnimationStepSettings, IColumn } from "../../types";
-import { getCollectionNames, renameAttributeInFormulas } from "../../helpers/codap-helpers";
+import { getCollectionNames } from "../../helpers/codap-helpers";
 import { isCollectorOnlyModel } from "../../utils/collector";
 
 interface IProps {
@@ -73,7 +73,7 @@ export const ColumnHeader = ({column, columnIndex}: IProps) => {
       const oldAttrName = globalState.attrMap[column.id].name;
       const attr = (await getAttribute(dataContextName, itemsCollectionName, oldAttrName)).values;
       await updateAttribute(dataContextName, itemsCollectionName, oldAttrName, attr, {name: newName});
-      await renameAttributeInFormulas(dataContextName, oldAttrName, newName);
+      // formulas that reference the attribute are CODAP's to update -- see renameAttributeInFormulas
       setColumnName(newName);
       setGlobalState(draft => {
         draft.model.columns[columnIndex].name = newName;

--- a/src/components/model/device-footer.test.tsx
+++ b/src/components/model/device-footer.test.tsx
@@ -126,6 +126,10 @@ describe("DeviceFooter", () => {
     fireEvent.click(screen.getByRole("button", { name: "Add Device" }));
 
     await waitFor(() => expect(warn).toHaveBeenCalled());
+    // the column is still there, with no attribute recorded behind it, and the model still renders
+    const newColumnId = store.globalState.model.columns[1].id;
+    expect(store.globalState.attrMap[newColumnId].codapID).toBeNull();
+    expect(screen.getByRole("button", { name: "DG.Plugin.Sampler.device-branch" })).toBeInTheDocument();
     warn.mockRestore();
   });
 

--- a/src/components/model/device-footer.test.tsx
+++ b/src/components/model/device-footer.test.tsx
@@ -4,7 +4,7 @@ import { useImmer } from "use-immer";
 import { createNewAttribute } from "@concord-consortium/codap-plugin-api";
 import { DeviceFooter } from "./device-footer";
 import { GlobalStateContext, getDefaultState } from "../../hooks/useGlobalState";
-import { IGlobalState } from "../../types";
+import { IGlobalState, IGlobalStateContext } from "../../types";
 
 jest.mock("@concord-consortium/codap-plugin-api", () => ({
   codapInterface: {
@@ -49,10 +49,12 @@ const dataContextName = "Sampler";
 const newAttributeId = "id-output2";
 
 // The component drives real state, so the state updates its handlers make are actually applied.
+let store: IGlobalStateContext;
 const StateProvider = ({ initialState, children }: { initialState: IGlobalState, children: React.ReactNode }) => {
   const [globalState, setGlobalState] = useImmer<IGlobalState>(initialState);
+  store = { globalState, setGlobalState };
   return (
-    <GlobalStateContext.Provider value={{ globalState, setGlobalState }}>
+    <GlobalStateContext.Provider value={store}>
       {children}
     </GlobalStateContext.Provider>
   );
@@ -125,6 +127,24 @@ describe("DeviceFooter", () => {
 
     await waitFor(() => expect(warn).toHaveBeenCalled());
     warn.mockRestore();
+  });
+
+  // Deleting the column takes its attrMap entry with it, and the create outlives that, so recording
+  // the id it comes back with has to cope with the entry being gone. Writing through it would throw
+  // inside the recipe.
+  it("survives the new column being deleted before its attribute comes back", async () => {
+    let finishCreate = (result: unknown) => { /* replaced below */ };
+    mockCreateNewAttribute.mockImplementation(() => new Promise(resolve => { finishCreate = resolve; }));
+    renderDeviceFooter();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Device" }));
+    await waitFor(() => expect(mockCreateNewAttribute).toHaveBeenCalledTimes(1));
+    const newColumnId = store.globalState.model.columns[1].id;
+
+    act(() => { store.setGlobalState(draft => { delete draft.attrMap[newColumnId]; }); });
+    await act(async () => { finishCreate({ success: true, values: { attrs: [{ id: newAttributeId }] } }); });
+
+    expect(store.globalState.attrMap[newColumnId]).toBeUndefined();
   });
 
   // An attrMap entry already carrying the new column's name is re-keyed onto it, and the attribute

--- a/src/components/model/device-footer.test.tsx
+++ b/src/components/model/device-footer.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useImmer } from "use-immer";
 import { createNewAttribute } from "@concord-consortium/codap-plugin-api";
 import { DeviceFooter } from "./device-footer";
@@ -58,13 +58,14 @@ const StateProvider = ({ initialState, children }: { initialState: IGlobalState,
   );
 };
 
-const renderDeviceFooter = () => {
+const renderDeviceFooter = ({ existingAttrNamed }: { existingAttrNamed?: string } = {}) => {
   const initialState: IGlobalState = getDefaultState();
   const column = initialState.model.columns[0];
   initialState.dataContextName = dataContextName;
   initialState.attrMap = {
     ...initialState.attrMap,
-    [column.id]: { codapID: "id-output", name: column.name }
+    [column.id]: { codapID: "id-output", name: column.name },
+    ...(existingAttrNamed ? { "stale-column": { codapID: "id-existing", name: existingAttrNamed } } : {})
   };
 
   render(
@@ -98,5 +99,42 @@ describe("DeviceFooter", () => {
 
     await waitFor(() => expect(mockCreateNewAttribute).toHaveBeenCalledTimes(1));
     expect(mockCreateNewAttribute).toHaveBeenCalledWith(dataContextName, itemsCollectionName, "output2");
+  });
+
+  // A create CODAP answers no to leaves the column with no attribute behind it, which is worth
+  // saying out loud even though the next run recreates it.
+  it("reports a create CODAP refuses", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    mockCreateNewAttribute.mockResolvedValue({ success: false });
+    renderDeviceFooter();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Device" }));
+
+    await waitFor(() => expect(warn).toHaveBeenCalledWith(expect.stringContaining("output2")));
+    warn.mockRestore();
+  });
+
+  // A create that stops answering is reported by tryRequest rather than here, so this checks the
+  // handler survives it rather than that it speaks up twice.
+  it("survives a create that never answers", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    mockCreateNewAttribute.mockRejectedValue(new Error("connection closed"));
+    renderDeviceFooter();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Device" }));
+
+    await waitFor(() => expect(warn).toHaveBeenCalled());
+    warn.mockRestore();
+  });
+
+  // An attrMap entry already carrying the new column's name is re-keyed onto it, and the attribute
+  // it names is already in CODAP, so asking for another one would be asking for a duplicate.
+  it("does not create an attribute when one already answers to the new column's name", async () => {
+    renderDeviceFooter({ existingAttrNamed: "output2" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Device" }));
+    await act(async () => undefined);
+
+    expect(mockCreateNewAttribute).not.toHaveBeenCalled();
   });
 });

--- a/src/components/model/device-footer.test.tsx
+++ b/src/components/model/device-footer.test.tsx
@@ -4,7 +4,6 @@ import { useImmer } from "use-immer";
 import { createNewAttribute } from "@concord-consortium/codap-plugin-api";
 import { DeviceFooter } from "./device-footer";
 import { GlobalStateContext, getDefaultState } from "../../hooks/useGlobalState";
-import { getCollectionNames } from "../../helpers/codap-helpers";
 import { IGlobalState } from "../../types";
 
 jest.mock("@concord-consortium/codap-plugin-api", () => ({
@@ -27,6 +26,21 @@ jest.mock("@concord-consortium/codap-plugin-api", () => ({
   getListOfDataContexts: jest.fn(),
   initializePlugin: jest.fn(),
   updateAttribute: jest.fn()
+}));
+
+// Stand in for a non-English locale, where the items collection is not named "items", so that the
+// expected collection name cannot come out of the same call the code under test makes. The rest are
+// named so the test reads in English; anything else resolves to its own id.
+const itemsCollectionName = "objekter";
+jest.mock("../../utils/localeManager", () => ({
+  tr: (key: string) => {
+    switch (key) {
+      case "DG.Plugin.Sampler.dataset.item-collection-name": return "objekter";
+      case "DG.Plugin.Sampler.dataset.attr-value": return "output";
+      case "DG.Plugin.Sampler.device-add": return "Add Device";
+      default: return key;
+    }
+  }
 }));
 
 const mockCreateNewAttribute = createNewAttribute as jest.Mock;
@@ -83,6 +97,6 @@ describe("DeviceFooter", () => {
     fireEvent.click(screen.getByRole("button", { name: "Add Device" }));
 
     await waitFor(() => expect(mockCreateNewAttribute).toHaveBeenCalledTimes(1));
-    expect(mockCreateNewAttribute).toHaveBeenCalledWith(dataContextName, getCollectionNames().items, "output2");
+    expect(mockCreateNewAttribute).toHaveBeenCalledWith(dataContextName, itemsCollectionName, "output2");
   });
 });

--- a/src/components/model/device-footer.test.tsx
+++ b/src/components/model/device-footer.test.tsx
@@ -90,7 +90,7 @@ describe("DeviceFooter", () => {
   });
 
   // A column added here has to reach CODAP right away. Otherwise its attribute is missing from the
-  // case table until the next experiment run happens to recreate it [SAMPLER-106].
+  // case table until the next experiment run happens to recreate it.
   it("creates the CODAP attribute for a newly added column", async () => {
     renderDeviceFooter();
 

--- a/src/components/model/device-footer.test.tsx
+++ b/src/components/model/device-footer.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useImmer } from "use-immer";
+import { createNewAttribute } from "@concord-consortium/codap-plugin-api";
+import { DeviceFooter } from "./device-footer";
+import { GlobalStateContext, getDefaultState } from "../../hooks/useGlobalState";
+import { getCollectionNames } from "../../helpers/codap-helpers";
+import { IGlobalState } from "../../types";
+
+jest.mock("@concord-consortium/codap-plugin-api", () => ({
+  codapInterface: {
+    sendRequest: jest.fn().mockResolvedValue({ success: true, values: {} }),
+    updateInteractiveState: jest.fn(),
+    on: jest.fn()
+  },
+  addDataContextChangeListener: jest.fn(),
+  createChildCollection: jest.fn(),
+  createDataContext: jest.fn(),
+  createNewAttribute: jest.fn(),
+  createParentCollection: jest.fn(),
+  getAllItems: jest.fn(),
+  getAttribute: jest.fn(),
+  getAttributeList: jest.fn(),
+  getCaseCount: jest.fn(),
+  getCollectionList: jest.fn(),
+  getDataContext: jest.fn(),
+  getListOfDataContexts: jest.fn(),
+  initializePlugin: jest.fn(),
+  updateAttribute: jest.fn()
+}));
+
+const mockCreateNewAttribute = createNewAttribute as jest.Mock;
+
+const dataContextName = "Sampler";
+const newAttributeId = "id-output2";
+
+// The component drives real state, so the state updates its handlers make are actually applied.
+const StateProvider = ({ initialState, children }: { initialState: IGlobalState, children: React.ReactNode }) => {
+  const [globalState, setGlobalState] = useImmer<IGlobalState>(initialState);
+  return (
+    <GlobalStateContext.Provider value={{ globalState, setGlobalState }}>
+      {children}
+    </GlobalStateContext.Provider>
+  );
+};
+
+const renderDeviceFooter = () => {
+  const initialState: IGlobalState = getDefaultState();
+  const column = initialState.model.columns[0];
+  initialState.dataContextName = dataContextName;
+  initialState.attrMap = {
+    ...initialState.attrMap,
+    [column.id]: { codapID: "id-output", name: column.name }
+  };
+
+  render(
+    <StateProvider initialState={initialState}>
+      <DeviceFooter
+        device={column.devices[0]}
+        columnIndex={0}
+        dataContexts={[]}
+        handleUpdateVariables={jest.fn()}
+        handleDeleteVariable={jest.fn()}
+        handleSelectDataContext={jest.fn()}
+        handleSpecifyVariables={jest.fn()}
+        clearFixedVariables={jest.fn()}
+      />
+    </StateProvider>
+  );
+};
+
+describe("DeviceFooter", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateNewAttribute.mockResolvedValue({ success: true, values: { attrs: [{ id: newAttributeId }] } });
+  });
+
+  // A column added here has to reach CODAP right away. Otherwise its attribute is missing from the
+  // case table until the next experiment run happens to recreate it [SAMPLER-106].
+  it("creates the CODAP attribute for a newly added column", async () => {
+    renderDeviceFooter();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Device" }));
+
+    await waitFor(() => expect(mockCreateNewAttribute).toHaveBeenCalledTimes(1));
+    expect(mockCreateNewAttribute).toHaveBeenCalledWith(dataContextName, getCollectionNames().items, "output2");
+  });
+});

--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -25,7 +25,7 @@ interface IProps {
 
 export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handleDeleteVariable, handleSelectDataContext, handleSpecifyVariables, clearFixedVariables, dataContexts}: IProps) => {
   const { globalState, setGlobalState } = useGlobalStateContext();
-  const { model, selectedDeviceId, isRunning, collectorContextName } = globalState;
+  const { model, selectedDeviceId, isRunning, collectorContextName, attrMap, dataContextName } = globalState;
   const { viewType, hidden } = device;
   const targetDevices = getTargetDevices(model, device);
   const siblingDevices = getSiblingDevices(model, device);
@@ -71,41 +71,48 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
   };
 
   const handleAddDevice = () => {
+    const currentDeviceViewType = model.columns[columnIndex].devices[0].viewType;
+    const newColumnIndex = columnIndex + 1;
+
+    if (model.columns[newColumnIndex]) {
+      // add the device
+      setGlobalState(draft => {
+        draft.model.columns[newColumnIndex].devices.push(createDefaultDevice(currentDeviceViewType));
+      });
+      updateFormulas();
+      return;
+    }
+
+    // create the column and add the same number devices as the current column
+    const name: string = getNewColumnName(defaultOutputAttrName, model.columns);
+    const id: string = createId();
+    const numNewDevices = model.columns[columnIndex].devices.length;
+    const newDevices = Array.from({length: numNewDevices}, () => createDefaultDevice(currentDeviceViewType));
+    // check if any attrs in attrMap have same name as new column name
+    // if so, replace the old attrMap key with the new id rather than adding a CODAP attribute
+    const existingAttr = Object.keys(attrMap).find((key) => attrMap[key].name === name);
+
     setGlobalState(draft => {
-      const currentDeviceViewType = draft.model.columns[columnIndex].devices[0].viewType;
-      const newColumnIndex = columnIndex + 1;
-      if (draft.model.columns[newColumnIndex]) {
-        // add the device
-        const newDevice = createDefaultDevice(currentDeviceViewType);
-        draft.model.columns[newColumnIndex].devices.push(newDevice);
+      draft.model.columns.splice(newColumnIndex, 0, {name, id, devices: newDevices});
+      if (existingAttr) {
+        draft.attrMap[id] = {...draft.attrMap[existingAttr]};
+        delete draft.attrMap[existingAttr];
       } else {
-        // create the column and add the same number devices as the current column
-        const name: string = getNewColumnName(defaultOutputAttrName, model.columns);
-        const id: string = createId();
-        const numNewDevices = model.columns[columnIndex].devices.length;
-        const newDevices = Array.from({length: numNewDevices}, () => createDefaultDevice(currentDeviceViewType));
-        draft.model.columns.splice(newColumnIndex, 0, {name, id, devices: newDevices});
-        // check if any attrs in attrMap have same name as new column name
-        // if so, replace the old attrMap key with the new id
-        const existingAttr = Object.keys(draft.attrMap).find((key) => draft.attrMap[key].name === name);
-        if (existingAttr) {
-          draft.attrMap[id] = {...draft.attrMap[existingAttr]};
-          delete draft.attrMap[existingAttr];
-        } else {
-          draft.attrMap[id] = {name, codapID: null};
-          if (draft.dataContextName) {
-            createNewAttribute(draft.dataContextName, getCollectionNames().items, name)
-              .then((result) => {
-                if (result.success && result.values.attrs?.[0]?.id) {
-                  setGlobalState(draft2 => {
-                    draft2.attrMap[id].codapID = result.values.attrs[0].id;
-                  });
-                }
-              });
-          }
-        }
+        draft.attrMap[id] = {name, codapID: null};
       }
     });
+
+    if (!existingAttr && dataContextName) {
+      createNewAttribute(dataContextName, getCollectionNames().items, name)
+        .then((result) => {
+          if (result.success && result.values.attrs?.[0]?.id) {
+            setGlobalState(draft => {
+              draft.attrMap[id].codapID = result.values.attrs[0].id;
+            });
+          }
+        });
+    }
+
     updateFormulas();
   };
 

--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -116,6 +116,9 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
                 draft.attrMap[id].codapID = result.values.attrs[0].id;
               }
             });
+          } else if (result) {
+            // tryRequest reports a request that never answered; this is one that answered no
+            console.warn(`Sampler: could not create the attribute for column ${name}`);
           }
         });
     }

--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -5,6 +5,7 @@ import { useGlobalStateContext } from "../../hooks/useGlobalState";
 import { getNumDevices, getSiblingDevices, getTargetDevices } from "../../models/model-model";
 import { getNewColumnName, getNewVariable, getProportionalVars } from "../helpers";
 import { createNewAttribute } from "@concord-consortium/codap-plugin-api";
+import { getCollectionNames } from "../../helpers/codap-helpers";
 import { createId } from "../../utils/id";
 import {IDataContext, IDevice, IVariables, defaultOutputAttrName, ViewType, deviceButtonLabels, deviceButtonTooltips}
   from "../../types";
@@ -92,8 +93,8 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
           delete draft.attrMap[existingAttr];
         } else {
           draft.attrMap[id] = {name, codapID: null};
-          if (draft.samplerContext) {
-            createNewAttribute(draft.samplerContext.name, "items", name)
+          if (draft.dataContextName) {
+            createNewAttribute(draft.dataContextName, getCollectionNames().items, name)
               .then((result) => {
                 if (result.success && result.values.attrs?.[0]?.id) {
                   setGlobalState(draft2 => {

--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -117,8 +117,9 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
               }
             });
           } else if (result) {
-            // tryRequest reports a request that never answered; this is one that answered no
-            console.warn(`Sampler: could not create the attribute for column ${name}`);
+            // tryRequest reports a request that never answered. This is one that answered, but
+            // either refused or came back without the id the column needs to recognise it later.
+            console.warn(`Sampler: CODAP did not create an attribute for column ${name}`);
           }
         });
     }

--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -112,6 +112,9 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
                 draft.attrMap[id].codapID = result.values.attrs[0].id;
               }
             });
+          } else {
+            // the next run recreates the attribute, so this is only worth reporting
+            console.error(`Could not create the CODAP attribute for column ${name}`);
           }
         })
         .catch(e => console.error(e));

--- a/src/components/model/device-footer.tsx
+++ b/src/components/model/device-footer.tsx
@@ -107,10 +107,14 @@ export const DeviceFooter = ({device, columnIndex, handleUpdateVariables, handle
         .then((result) => {
           if (result.success && result.values.attrs?.[0]?.id) {
             setGlobalState(draft => {
-              draft.attrMap[id].codapID = result.values.attrs[0].id;
+              // the column can be deleted while this is in flight, taking its attrMap entry with it
+              if (draft.attrMap[id]) {
+                draft.attrMap[id].codapID = result.values.attrs[0].id;
+              }
             });
           }
-        });
+        })
+        .catch(e => console.error(e));
     }
 
     updateFormulas();

--- a/src/components/model/model-component.scss
+++ b/src/components/model/model-component.scss
@@ -353,11 +353,13 @@ $pluginMinWidth: 304px;
         width: 100%;
       }
 
-      // positioned like the label so that saying why a rename did not take does not move the model
+      // out of flow so that saying why a rename did not take does not move the model, and below the
+      // label rather than on top of it, since a message can still be showing when a run starts
       .device-column-header-message {
         font-size: 11px;
         color: #b00020;
         position: absolute;
+        top: 20px;
         width: 100%;
       }
     }

--- a/src/components/model/model-component.scss
+++ b/src/components/model/model-component.scss
@@ -352,6 +352,14 @@ $pluginMinWidth: 304px;
         position: absolute;
         width: 100%;
       }
+
+      // positioned like the label so that saying why a rename did not take does not move the model
+      .device-column-header-message {
+        font-size: 11px;
+        color: #b00020;
+        position: absolute;
+        width: 100%;
+      }
     }
   }
 }

--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -458,8 +458,12 @@ export const getNewExperimentInfo = async (dataContextName: string, experimentHa
 // handling, so a formula there keeps the old name after a rename. Rewriting formulas safely means
 // parsing them the way CODAP parses them rather than approximating it here.
 //
-// If we decide v2 does not need fixing, delete this and the commented-out imports above it. To put
-// it back, uncomment those imports and add getCollectionList to the plugin api import.
+// If we decide v2 does not need fixing, delete this and the commented-out imports above it, along
+// with renameVariable in utils/formula-parser, whose only caller is below. To put this back,
+// uncomment those imports and add getCollectionList to the plugin api import.
+//
+// Being commented out, none of it is checked by TypeScript or ESLint, so it will not be told when
+// the API or the types it uses move underneath it.
 //
 // export const renameAttributeInFormulas = async (dataContextName: string, oldName: string, newName: string) => {
 //   const collectionListResult = await getCollectionList(dataContextName);

--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -9,14 +9,15 @@ import {
   getAttribute,
   getAttributeList,
   getCaseCount,
-  getCollectionList,
   getDataContext,
   getListOfDataContexts,
   updateAttribute} from "@concord-consortium/codap-plugin-api";
 import { AttrMap, IAttribute, IGlobalState } from "../types";
 import { Updater } from "use-immer";
-import { parseFormula } from "../utils/utils";
-import { renameVariable, stringify } from "../utils/formula-parser";
+// these are only used by the commented-out renameAttributeInFormulas below, along with
+// getCollectionList from the plugin api import above
+// import { parseFormula } from "../utils/utils";
+// import { renameVariable, stringify } from "../utils/formula-parser";
 import { kPluginName } from "../constants";
 import { tr } from "../utils/localeManager";
 
@@ -384,50 +385,55 @@ export const getNewExperimentInfo = async (dataContextName: string, experimentHa
   return {experimentNum, startingSampleNumber};
 };
 
-// Nothing calls this. CODAP v3 keeps formulas that reference a renamed attribute correct on its own --
-// it stores them against attribute ids and regenerates the displayed text -- so calling this would
-// overwrite a correct formula with the output of the parser below, which drops backticks and quotes and
-// turns references to other attributes into string constants. CODAP v2 does need the rewrite, but doing
-// it safely means parsing formulas the way CODAP parses them rather than approximating it here.
-export const renameAttributeInFormulas = async (dataContextName: string, oldName: string, newName: string) => {
-  const collectionListResult = await getCollectionList(dataContextName);
-  if (!collectionListResult.success) {
-    return;
-  }
-
-  const collections = collectionListResult.values.map((c: any) => c.name);
-  for (const collection of collections) {
-    const attrListResult = await getAttributeList(dataContextName, collection);
-    if (!attrListResult.success) {
-      continue;
-    }
-
-    const attributes = attrListResult.values;
-    for (const attr of attributes) {
-      const attributeResult = await getAttribute(dataContextName, collection, attr.name);
-      if (!attributeResult.success) {
-        continue;
-      }
-      const { formula } = attributeResult.values;
-
-      // a bug in CODAPv2 causes multiple equals signs to be added to formulas when renaming attributes
-      let finalFormula = formula?.replace(/={1,}/g, "=");
-
-      if (finalFormula?.includes(oldName)) {
-        // this returns a binary expression of left: "", op: =, right: parsedFormula
-        // so we only need to update the variable name in the right side
-        const parsed = parseFormula(finalFormula, "");
-        if (parsed.type === "BinaryExpression") {
-          const renamed = renameVariable(parsed.right, oldName, newName);
-          finalFormula = stringify(renamed, [newName]);
-        }
-      }
-      if (finalFormula !== formula) {
-        await updateAttribute(dataContextName, collection, attr.name, attr, {formula: finalFormula});
-      }
-    }
-  }
-};
+// Kept in case CODAP v2 needs it. CODAP v3 keeps formulas that reference a renamed attribute correct
+// on its own -- it stores them against attribute ids and regenerates the displayed text -- so calling
+// this overwrote a correct formula with the output of the parser below, which drops backticks and
+// quotes and turns references to other attributes into string constants. CODAP v2 has no such
+// handling, but it has also gone without this since SAMPLER-78 made the call unreachable. Rewriting
+// formulas safely means parsing them the way CODAP parses them rather than approximating it here.
+//
+// If we decide v2 does not need fixing, delete this along with the parseFormula, renameVariable and
+// stringify imports, which nothing else in this file uses.
+//
+// export const renameAttributeInFormulas = async (dataContextName: string, oldName: string, newName: string) => {
+//   const collectionListResult = await getCollectionList(dataContextName);
+//   if (!collectionListResult.success) {
+//     return;
+//   }
+//
+//   const collections = collectionListResult.values.map((c: any) => c.name);
+//   for (const collection of collections) {
+//     const attrListResult = await getAttributeList(dataContextName, collection);
+//     if (!attrListResult.success) {
+//       continue;
+//     }
+//
+//     const attributes = attrListResult.values;
+//     for (const attr of attributes) {
+//       const attributeResult = await getAttribute(dataContextName, collection, attr.name);
+//       if (!attributeResult.success) {
+//         continue;
+//       }
+//       const { formula } = attributeResult.values;
+//
+//       // a bug in CODAPv2 causes multiple equals signs to be added to formulas when renaming attributes
+//       let finalFormula = formula?.replace(/={1,}/g, "=");
+//
+//       if (finalFormula?.includes(oldName)) {
+//         // this returns a binary expression of left: "", op: =, right: parsedFormula
+//         // so we only need to update the variable name in the right side
+//         const parsed = parseFormula(finalFormula, "");
+//         if (parsed.type === "BinaryExpression") {
+//           const renamed = renameVariable(parsed.right, oldName, newName);
+//           finalFormula = stringify(renamed, [newName]);
+//         }
+//       }
+//       if (finalFormula !== formula) {
+//         await updateAttribute(dataContextName, collection, attr.name, attr, {formula: finalFormula});
+//       }
+//     }
+//   }
+// };
 
 
 type Dimensions = {width: number; height: number};

--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -14,8 +14,7 @@ import {
   updateAttribute} from "@concord-consortium/codap-plugin-api";
 import { AttrMap, IAttribute, IGlobalState } from "../types";
 import { Updater } from "use-immer";
-// these are only used by the commented-out renameAttributeInFormulas below, along with
-// getCollectionList from the plugin api import above
+// only the commented-out renameAttributeInFormulas below uses these
 // import { parseFormula } from "../utils/utils";
 // import { renameVariable, stringify } from "../utils/formula-parser";
 import { kPluginName } from "../constants";
@@ -356,7 +355,7 @@ export const getNewExperimentInfo = async (dataContextName: string, experimentHa
   // any cases?
   if (result.values.length > 0) {
     /*
-      This has been disabled due to a request to always create a new experiment in SAMPLER-82.
+      This has been disabled due to a request to always create a new experiment.
       If this turns out not to be the desired behavior in the future, this can be uncommented and
       the code below that sets an empty array for matchingHashItems can be removed.
 
@@ -389,11 +388,12 @@ export const getNewExperimentInfo = async (dataContextName: string, experimentHa
 // on its own -- it stores them against attribute ids and regenerates the displayed text -- so calling
 // this overwrote a correct formula with the output of the parser below, which drops backticks and
 // quotes and turns references to other attributes into string constants. CODAP v2 has no such
-// handling, but it has also gone without this since SAMPLER-78 made the call unreachable. Rewriting
-// formulas safely means parsing them the way CODAP parses them rather than approximating it here.
+// handling, but it has also gone without this ever since an earlier change to initialization left
+// the call unreachable. Rewriting formulas safely means parsing them the way CODAP parses them
+// rather than approximating it here.
 //
-// If we decide v2 does not need fixing, delete this along with the parseFormula, renameVariable and
-// stringify imports, which nothing else in this file uses.
+// If we decide v2 does not need fixing, delete this and the commented-out imports above it. To put
+// it back, uncomment those imports and add getCollectionList to the plugin api import.
 //
 // export const renameAttributeInFormulas = async (dataContextName: string, oldName: string, newName: string) => {
 //   const collectionListResult = await getCollectionList(dataContextName);

--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -50,17 +50,18 @@ export const getCollectionNames = () => {
 };
 
 const updateAttributeIds = async (dataContextName: string, attrs: Array<string>, attrMap: AttrMap, setGlobalState: Updater<IGlobalState>) => {
+  const {experiments, samples} = getCollectionNames();
   const allAttrs = [
-    {collection: "experiments", attrName: attrMap.experiment.name},
-    {collection: "experiments", attrName: attrMap.description.name},
-    {collection: "experiments", attrName: attrMap.sample_size.name},
-    {collection: "experiments", attrName: attrMap.until_formula.name},
-    {collection: "experiments", attrName: attrMap.experimentHash.name},
-    {collection: "samples", attrName: attrMap.sample.name},
+    {collection: experiments, attrName: attrMap.experiment.name},
+    {collection: experiments, attrName: attrMap.description.name},
+    {collection: experiments, attrName: attrMap.sample_size.name},
+    {collection: experiments, attrName: attrMap.until_formula.name},
+    {collection: experiments, attrName: attrMap.experimentHash.name},
+    {collection: samples, attrName: attrMap.sample.name},
   ];
   const isKeyOfAttrMap = (key: any): key is keyof AttrMap => key in attrMap;
 
-  attrs.forEach(attr => allAttrs.push({collection: "samples", attrName: attr}));
+  attrs.forEach(attr => allAttrs.push({collection: samples, attrName: attr}));
 
   const reqs: TCODAPRequest[] = allAttrs.map(collectionAttr => ({
     "action": "get",
@@ -203,9 +204,6 @@ export const findOrCreateDataContext = async (initialDataContextName: string, at
     const createRes = await createDataContext(finalDataContextName);
     const itemsAttrs: IAttribute[] = [];
     if (createRes.success) {
-      setGlobalState((draft) => {
-        draft.samplerContext = createRes.values;
-      });
       const parentAttrs = [
         {name: attrMap.experiment.name, type: "categorical"},
         {name: attrMap.description.name, type: "categorical"},

--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -50,7 +50,7 @@ export const getCollectionNames = () => {
 };
 
 const updateAttributeIds = async (dataContextName: string, attrs: Array<string>, attrMap: AttrMap, setGlobalState: Updater<IGlobalState>) => {
-  const {experiments, samples} = getCollectionNames();
+  const {experiments, samples, items} = getCollectionNames();
   const allAttrs = [
     {collection: experiments, attrName: attrMap.experiment.name},
     {collection: experiments, attrName: attrMap.description.name},
@@ -61,7 +61,8 @@ const updateAttributeIds = async (dataContextName: string, attrs: Array<string>,
   ];
   const isKeyOfAttrMap = (key: any): key is keyof AttrMap => key in attrMap;
 
-  attrs.forEach(attr => allAttrs.push({collection: samples, attrName: attr}));
+  // the attributes standing for the model's columns belong to the items collection
+  attrs.forEach(attr => allAttrs.push({collection: items, attrName: attr}));
 
   const reqs: TCODAPRequest[] = allAttrs.map(collectionAttr => ({
     "action": "get",

--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -383,6 +383,11 @@ export const getNewExperimentInfo = async (dataContextName: string, experimentHa
   return {experimentNum, startingSampleNumber};
 };
 
+// Nothing calls this. CODAP v3 keeps formulas that reference a renamed attribute correct on its own --
+// it stores them against attribute ids and regenerates the displayed text -- so calling this would
+// overwrite a correct formula with the output of the parser below, which drops backticks and quotes and
+// turns references to other attributes into string constants. CODAP v2 does need the rewrite, but doing
+// it safely means parsing formulas the way CODAP parses them rather than approximating it here.
 export const renameAttributeInFormulas = async (dataContextName: string, oldName: string, newName: string) => {
   const collectionListResult = await getCollectionList(dataContextName);
   if (!collectionListResult.success) {

--- a/src/helpers/codap-helpers.tsx
+++ b/src/helpers/codap-helpers.tsx
@@ -422,9 +422,9 @@ export const getNewExperimentInfo = async (dataContextName: string, experimentHa
   // any cases?
   if (result.values.length > 0) {
     /*
-      This has been disabled due to a request to always create a new experiment.
-      If this turns out not to be the desired behavior in the future, this can be uncommented and
-      the code below that sets an empty array for matchingHashItems can be removed.
+      Every run starts a new experiment, so a run matching an existing one is never looked for.
+      If matching is wanted again, this can be uncommented and the code below that sets an empty
+      array for matchingHashItems can be removed.
 
     // check if the experiment already exists
     const matchingHashItems = result.values.filter((item: any) => item.values?.experimentHash === experimentHash);
@@ -455,9 +455,8 @@ export const getNewExperimentInfo = async (dataContextName: string, experimentHa
 // on its own -- it stores them against attribute ids and regenerates the displayed text -- so calling
 // this overwrote a correct formula with the output of the parser below, which drops backticks and
 // quotes and turns references to other attributes into string constants. CODAP v2 has no such
-// handling, but it has also gone without this ever since an earlier change to initialization left
-// the call unreachable. Rewriting formulas safely means parsing them the way CODAP parses them
-// rather than approximating it here.
+// handling, so a formula there keeps the old name after a rename. Rewriting formulas safely means
+// parsing them the way CODAP parses them rather than approximating it here.
 //
 // If we decide v2 does not need fixing, delete this and the commented-out imports above it. To put
 // it back, uncomment those imports and add getCollectionList to the plugin api import.

--- a/src/hooks/useGlobalState.test.tsx
+++ b/src/hooks/useGlobalState.test.tsx
@@ -1,5 +1,6 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import {
+  addDataContextChangeListener,
   codapInterface,
   createChildCollection,
   createDataContext,
@@ -37,6 +38,7 @@ jest.mock("@concord-consortium/codap-plugin-api", () => ({
   updateAttribute: jest.fn()
 }));
 
+const mockAddDataContextChangeListener = addDataContextChangeListener as jest.Mock;
 const mockCodapInterface = codapInterface as jest.Mocked<typeof codapInterface>;
 const mockCreateChildCollection = createChildCollection as jest.Mock;
 const mockCreateDataContext = createDataContext as jest.Mock;
@@ -152,5 +154,27 @@ describe("useGlobalStateContextValue initialization", () => {
     await waitFor(() => expect(result.current.globalState.dataContextName).toBe(dataContextName));
 
     expect(result.current.globalState.attrMap[savedColumnId].codapID).toBe(`id-${defaultOutputAttrName}`);
+  });
+
+  // A listener cannot be removed once added, so subscribing to a name a second time would handle
+  // every notification for it twice, for as long as the plugin is open. The name can return to an
+  // earlier value: init leaves it empty when the data context cannot be found, and starting an
+  // experiment sets it again.
+  it("subscribes to a data context once however often its name comes back", async () => {
+    const { result } = renderHook(() => useGlobalStateContextValue());
+    await waitFor(() => expect(result.current.globalState.dataContextName).toBe(dataContextName));
+    expect(mockAddDataContextChangeListener).toHaveBeenCalledTimes(1);
+
+    const setName = (name: string) =>
+      act(() => { result.current.setGlobalState(draft => { draft.dataContextName = name; }); });
+
+    setName("");
+    setName(dataContextName);
+    setName("another context");
+    setName(dataContextName);
+
+    expect(mockAddDataContextChangeListener).toHaveBeenCalledTimes(2);
+    expect(mockAddDataContextChangeListener.mock.calls.map(([name]: [string]) => name))
+      .toEqual([dataContextName, "another context"]);
   });
 });

--- a/src/hooks/useGlobalState.test.tsx
+++ b/src/hooks/useGlobalState.test.tsx
@@ -4,12 +4,15 @@ import {
   createChildCollection,
   createDataContext,
   createParentCollection,
+  getAttributeList,
   getDataContext,
   getListOfDataContexts,
   initializePlugin} from "@concord-consortium/codap-plugin-api";
 import { useGlobalStateContextValue } from "./useGlobalState";
 import { defaultOutputAttrName } from "../types";
 import { getCollectionNames } from "../helpers/codap-helpers";
+import { createDefaultDevice } from "../models/device-model";
+import { defaultAttrMap } from "../utils/attr-map";
 import { tr } from "../utils/localeManager";
 
 jest.mock("@concord-consortium/codap-plugin-api", () => ({
@@ -38,6 +41,7 @@ const mockCodapInterface = codapInterface as jest.Mocked<typeof codapInterface>;
 const mockCreateChildCollection = createChildCollection as jest.Mock;
 const mockCreateDataContext = createDataContext as jest.Mock;
 const mockCreateParentCollection = createParentCollection as jest.Mock;
+const mockGetAttributeList = getAttributeList as jest.Mock;
 const mockGetDataContext = getDataContext as jest.Mock;
 const mockGetListOfDataContexts = getListOfDataContexts as jest.Mock;
 const mockInitializePlugin = initializePlugin as jest.Mock;
@@ -122,5 +126,30 @@ describe("useGlobalStateContextValue initialization", () => {
       resource.endsWith(`.attribute[${defaultOutputAttrName}]`));
 
     expect(columnAttrRequest).toContain(`collection[${getCollectionNames().items}]`);
+  });
+
+  // The reported bug was worst in a document that was reloaded rather than created: it already has
+  // an instance, so init takes the branch that reaches the trailing state write directly, and the
+  // data context already exists so nothing sets it up along the way [SAMPLER-106].
+  it("keeps the attribute ids it looked up in a reloaded document", async () => {
+    const savedColumnId = "saved-column";
+    mockInitializePlugin.mockResolvedValue({
+      instance: 1,
+      dataContextName,
+      model: { columns: [{ name: defaultOutputAttrName, id: savedColumnId, devices: [createDefaultDevice()] }] },
+      attrMap: { ...defaultAttrMap, [savedColumnId]: { codapID: null, name: defaultOutputAttrName } }
+    });
+    mockGetDataContext.mockResolvedValue({ success: true, values: { name: dataContextName } });
+    mockGetAttributeList.mockResolvedValue({ success: true, values: [
+      { name: defaultAttrMap.sample_size.name },
+      { name: defaultAttrMap.experimentHash.name },
+      { name: defaultOutputAttrName }
+    ] });
+
+    const { result } = renderHook(() => useGlobalStateContextValue());
+
+    await waitFor(() => expect(result.current.globalState.dataContextName).toBe(dataContextName));
+
+    expect(result.current.globalState.attrMap[savedColumnId].codapID).toBe(`id-${defaultOutputAttrName}`);
   });
 });

--- a/src/hooks/useGlobalState.test.tsx
+++ b/src/hooks/useGlobalState.test.tsx
@@ -58,8 +58,9 @@ const createdDataContext = { name: dataContextName, id: 1, title: dataContextNam
 
 // updateAttributeIds asks CODAP for every attribute by name in one batched request. CODAP answers
 // with the attribute's id, which the plugin stores in attrMap so it can recognize the attribute
-// later when CODAP reports a change to it. A request naming a collection that does not exist fails,
-// exactly as CODAP would answer it.
+// later when CODAP reports a change to it. This is deliberately stricter than CODAP, which resolves
+// an attribute by name across the whole data context and so would answer a request naming the wrong
+// collection: being strict is what lets these tests tell the right collection from a wrong one.
 const attributeIdRequestResponse = (resource: string) => {
   const [, collection, name] = resource.match(/collection\[(.*)\]\.attribute\[(.*)\]$/) ?? [];
   if (!Object.values(getCollectionNames()).includes(collection)) {
@@ -100,7 +101,7 @@ describe("useGlobalStateContextValue initialization", () => {
   });
 
   // The plugin matches CODAP's change notifications against these ids, so losing them means a
-  // rename made in the case table is never applied to the model [SAMPLER-106].
+  // rename made in the case table is never applied to the model.
   it("keeps the attribute ids it looked up", async () => {
     const { result } = renderHook(() => useGlobalStateContextValue());
 
@@ -129,8 +130,8 @@ describe("useGlobalStateContextValue initialization", () => {
   });
 
   // The reported bug was worst in a document that was reloaded rather than created: it already has
-  // an instance, so init takes the branch that reaches the trailing state write directly, and the
-  // data context already exists so nothing sets it up along the way [SAMPLER-106].
+  // an instance, so init records the data context name directly rather than inside the lock
+  // callback, and the data context already exists so nothing sets it up along the way.
   it("keeps the attribute ids it looked up in a reloaded document", async () => {
     const savedColumnId = "saved-column";
     mockInitializePlugin.mockResolvedValue({

--- a/src/hooks/useGlobalState.test.tsx
+++ b/src/hooks/useGlobalState.test.tsx
@@ -129,8 +129,8 @@ describe("useGlobalStateContextValue initialization", () => {
     expect(columnAttrRequest).toContain(`collection[${getCollectionNames().items}]`);
   });
 
-  // The reported bug was worst in a document that was reloaded rather than created: it already has
-  // an instance, so init records the data context name directly rather than inside the lock
+  // A document that was reloaded rather than created takes the other path through init: it already
+  // has an instance, so the data context name is recorded directly rather than inside the lock
   // callback, and the data context already exists so nothing sets it up along the way.
   it("keeps the attribute ids it looked up in a reloaded document", async () => {
     const savedColumnId = "saved-column";

--- a/src/hooks/useGlobalState.test.tsx
+++ b/src/hooks/useGlobalState.test.tsx
@@ -106,4 +106,21 @@ describe("useGlobalStateContextValue initialization", () => {
     const { attrMap, model } = result.current.globalState;
     expect(attrMap[model.columns[0].id].codapID).toBe(`id-${defaultOutputAttrName}`);
   });
+
+  // CODAP resolves an attribute by name across the whole data context, so naming the wrong
+  // collection still finds it. Ask for the collection the attribute actually belongs to anyway,
+  // rather than leaning on that.
+  it("looks up a column's attribute in the collection that holds it", async () => {
+    renderHook(() => useGlobalStateContextValue());
+    await waitFor(() => expect(mockCodapInterface.sendRequest).toHaveBeenCalled());
+
+    const resources: string[] = [];
+    mockCodapInterface.sendRequest.mock.calls.forEach(([request]: any) => {
+      (Array.isArray(request) ? request : [request]).forEach((r: any) => r?.resource && resources.push(r.resource));
+    });
+    const columnAttrRequest = resources.find(resource =>
+      resource.endsWith(`.attribute[${defaultOutputAttrName}]`));
+
+    expect(columnAttrRequest).toContain(`collection[${getCollectionNames().items}]`);
+  });
 });

--- a/src/hooks/useGlobalState.test.tsx
+++ b/src/hooks/useGlobalState.test.tsx
@@ -1,0 +1,109 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import {
+  codapInterface,
+  createChildCollection,
+  createDataContext,
+  createParentCollection,
+  getDataContext,
+  getListOfDataContexts,
+  initializePlugin} from "@concord-consortium/codap-plugin-api";
+import { useGlobalStateContextValue } from "./useGlobalState";
+import { defaultOutputAttrName } from "../types";
+import { getCollectionNames } from "../helpers/codap-helpers";
+import { tr } from "../utils/localeManager";
+
+jest.mock("@concord-consortium/codap-plugin-api", () => ({
+  codapInterface: {
+    sendRequest: jest.fn(),
+    updateInteractiveState: jest.fn(),
+    on: jest.fn()
+  },
+  addDataContextChangeListener: jest.fn(),
+  createChildCollection: jest.fn(),
+  createDataContext: jest.fn(),
+  createNewAttribute: jest.fn(),
+  createParentCollection: jest.fn(),
+  getAllItems: jest.fn(),
+  getAttribute: jest.fn(),
+  getAttributeList: jest.fn(),
+  getCaseCount: jest.fn(),
+  getCollectionList: jest.fn(),
+  getDataContext: jest.fn(),
+  getListOfDataContexts: jest.fn(),
+  initializePlugin: jest.fn(),
+  updateAttribute: jest.fn()
+}));
+
+const mockCodapInterface = codapInterface as jest.Mocked<typeof codapInterface>;
+const mockCreateChildCollection = createChildCollection as jest.Mock;
+const mockCreateDataContext = createDataContext as jest.Mock;
+const mockCreateParentCollection = createParentCollection as jest.Mock;
+const mockGetDataContext = getDataContext as jest.Mock;
+const mockGetListOfDataContexts = getListOfDataContexts as jest.Mock;
+const mockInitializePlugin = initializePlugin as jest.Mock;
+
+// Every string resolves to its own id, standing in for a locale whose collection names are not the
+// English "experiments"/"samples"/"items".
+jest.mock("../utils/localeManager", () => ({
+  tr: (key: string) => key
+}));
+
+// The name findOrCreateDataContext settles on when no data context exists yet.
+const dataContextName = tr("DG.Plugin.Sampler.dataset.name");
+const createdDataContext = { name: dataContextName, id: 1, title: dataContextName };
+
+// updateAttributeIds asks CODAP for every attribute by name in one batched request. CODAP answers
+// with the attribute's id, which the plugin stores in attrMap so it can recognize the attribute
+// later when CODAP reports a change to it. A request naming a collection that does not exist fails,
+// exactly as CODAP would answer it.
+const attributeIdRequestResponse = (resource: string) => {
+  const [, collection, name] = resource.match(/collection\[(.*)\]\.attribute\[(.*)\]$/) ?? [];
+  if (!Object.values(getCollectionNames()).includes(collection)) {
+    return { success: false };
+  }
+  return { success: true, values: { name, id: `id-${name}` } };
+};
+
+describe("useGlobalStateContextValue initialization", () => {
+  beforeAll(() => {
+    // jsdom has no Web Locks API. Match the browser: the callback runs asynchronously and the
+    // caller does not await it.
+    Object.defineProperty(navigator, "locks", {
+      configurable: true,
+      value: { request: (_name: string, callback: () => Promise<void>) => Promise.resolve().then(callback) }
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // a new document: no saved plugin state and no existing data context
+    mockInitializePlugin.mockResolvedValue(undefined);
+    mockGetListOfDataContexts.mockResolvedValue({ success: true, values: [] });
+    mockGetDataContext.mockResolvedValue({ success: false });
+
+    mockCreateDataContext.mockResolvedValue({ success: true, values: createdDataContext });
+    mockCreateParentCollection.mockResolvedValue({ success: true });
+    mockCreateChildCollection.mockResolvedValue({ success: true });
+
+    mockCodapInterface.sendRequest.mockImplementation((request: any, callback?: any) => {
+      const response = Array.isArray(request)
+        ? request.map((r: { resource: string }) => attributeIdRequestResponse(r.resource))
+        : { success: true, values: {} };
+      callback?.(response);
+      return Promise.resolve(response);
+    });
+  });
+
+  // The plugin matches CODAP's change notifications against these ids, so losing them means a
+  // rename made in the case table is never applied to the model [SAMPLER-106].
+  it("keeps the attribute ids it looked up", async () => {
+    const { result } = renderHook(() => useGlobalStateContextValue());
+
+    // init writes the data context name into state last, so this is where it has settled
+    await waitFor(() => expect(result.current.globalState.dataContextName).toBe(dataContextName));
+
+    const { attrMap, model } = result.current.globalState;
+    expect(attrMap[model.columns[0].id].codapID).toBe(`id-${defaultOutputAttrName}`);
+  });
+});

--- a/src/hooks/useGlobalState.tsx
+++ b/src/hooks/useGlobalState.tsx
@@ -130,7 +130,7 @@ export const migrateState = (state: IGlobalState) => {
 
 export const useGlobalStateContextValue = (): IGlobalStateContext => {
   const [globalState, setGlobalState] = useImmer<IGlobalState>(getDefaultState());
-  const listenedToDataContextName = useRef("");
+  const listenedToDataContextNames = useRef(new Set<string>());
 
   useEffect(() => {
     const init = async () => {
@@ -227,10 +227,11 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
 
   useEffect(() => {
     // Listeners cannot be removed, so a data context name we have already subscribed to must not be
-    // subscribed to again. The name can return to an earlier value -- init leaves it empty when the
-    // data context could not be found and starting an experiment sets it again -- and every
-    // notification would then be handled once per registration.
-    if (globalState.dataContextName && globalState.dataContextName !== listenedToDataContextName.current) {
+    // subscribed to again. The name can return to any earlier value -- init leaves it empty when the
+    // data context could not be found, starting an experiment sets it again, and a collector can
+    // point the plugin at a different context and back -- and every notification would then be
+    // handled once per registration, permanently. Hence every name seen, not just the last one.
+    if (globalState.dataContextName && !listenedToDataContextNames.current.has(globalState.dataContextName)) {
       addDataContextChangeListener(globalState.dataContextName, (msg: any) => {
         if (msg.values.operation === "updateAttributes") {
           msg.values.result.attrIDs.forEach((id: string, i: number) => {
@@ -246,7 +247,7 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
           });
         }
       });
-      listenedToDataContextName.current = globalState.dataContextName;
+      listenedToDataContextNames.current.add(globalState.dataContextName);
     }
 
   }, [globalState.dataContextName, setGlobalState]);

--- a/src/hooks/useGlobalState.tsx
+++ b/src/hooks/useGlobalState.tsx
@@ -26,7 +26,6 @@ export const getDefaultState = (): IGlobalState => {
     attrMap: defaultAttrMap,
     dataContextName: "",
     collectorContextName: "",
-    samplerContext: undefined,
     isRunning: false,
     isPaused: false,
     speed: 1,
@@ -170,6 +169,14 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
       const isCollector = isCollectorOnlyModel(newGlobalState.model);
       const attrs = isCollector ? getCollectorAttrs(newGlobalState.model) : getModelAttrs(newGlobalState.model);
 
+      // Publish the migrated state before touching CODAP. findOrCreateDataContext writes the
+      // attribute ids it looks up back into the state it finds, so it has to find this state and
+      // not the placeholder the hook started with — the placeholder is a separate getDefaultState()
+      // whose column has a different id, which would leave the column's attribute id unrecorded.
+      // Everything after this point updates individual properties for the same reason: replacing
+      // the whole state would discard whatever findOrCreateDataContext had just written.
+      setGlobalState(newGlobalState);
+
       const ensureDataContext = async (instance: number) => {
         const {dataContextName, attrMap, repeat} = newGlobalState;
         const newDataContextName = await findOrCreateDataContext(dataContextName, attrs, attrMap, setGlobalState, repeat, isCollector, instance, false);
@@ -192,14 +199,19 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
           }
           await updatePluginTitle(instance);
           finalDataContextName = await ensureDataContext(instance);
-          setGlobalState({...newGlobalState, instance, dataContextName: finalDataContextName});
+          setGlobalState(draft => {
+            draft.instance = instance;
+            draft.dataContextName = finalDataContextName;
+          });
         });
       } else {
         finalDataContextName = await ensureDataContext(newGlobalState.instance);
         await updatePluginTitle(newGlobalState.instance);
       }
 
-      setGlobalState({...newGlobalState, dataContextName: finalDataContextName});
+      setGlobalState(draft => {
+        draft.dataContextName = finalDataContextName;
+      });
     };
 
     init();
@@ -210,8 +222,8 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
   }, [globalState]);
 
   useEffect(() => {
-    if (globalState.samplerContext) {
-      addDataContextChangeListener(globalState.samplerContext.name, (msg: any) => {
+    if (globalState.dataContextName) {
+      addDataContextChangeListener(globalState.dataContextName, (msg: any) => {
         if (msg.values.operation === "updateAttributes") {
           msg.values.result.attrIDs.forEach((id: string, i: number) => {
             const newName = msg.values.result.attrs[i].name;
@@ -228,7 +240,7 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
       });
     }
 
-  }, [globalState.samplerContext, setGlobalState]);
+  }, [globalState.dataContextName, setGlobalState]);
 
   return {
     globalState,

--- a/src/hooks/useGlobalState.tsx
+++ b/src/hooks/useGlobalState.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect } from "react";
+import { createContext, useContext, useEffect, useRef } from "react";
 import { useImmer } from "use-immer";
 import {IColumn, IGlobalState, IGlobalStateContext, ITPSamplerPluginState, defaultOutputAttrName, Speed, ViewType}
   from "../types";
@@ -130,6 +130,7 @@ export const migrateState = (state: IGlobalState) => {
 
 export const useGlobalStateContextValue = (): IGlobalStateContext => {
   const [globalState, setGlobalState] = useImmer<IGlobalState>(getDefaultState());
+  const listenedToDataContextName = useRef("");
 
   useEffect(() => {
     const init = async () => {
@@ -174,7 +175,9 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
       // not the placeholder the hook started with — the placeholder is a separate getDefaultState()
       // whose column has a different id, which would leave the column's attribute id unrecorded.
       // Everything after this point updates individual properties for the same reason: replacing
-      // the whole state would discard whatever findOrCreateDataContext had just written.
+      // the whole state would discard whatever findOrCreateDataContext had just written. This is
+      // the only place left that replaces the state wholesale, so nothing may write global state
+      // before it lands -- such a write would be discarded here.
       setGlobalState(newGlobalState);
 
       const ensureDataContext = async (instance: number) => {
@@ -183,11 +186,11 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
         return newDataContextName ?? "";
       };
 
-      let finalDataContextName = newGlobalState.dataContextName;
-
       if (!newGlobalState.instance) {
         // only allow one instance of the sampler plugin access to the global value
-        // at a time to avoid race conditions when multiple instances are initialized
+        // at a time to avoid race conditions when multiple instances are initialized.
+        // This is deliberately not awaited, so the data context name is recorded inside the
+        // callback -- anything after this block would run before the callback has one.
         navigator.locks.request(kSamplerInstanceGlobalValueName, async () => {
           let instance = 1;
           let globalValue = await getGlobalValue(kSamplerInstanceGlobalValueName);
@@ -198,20 +201,19 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
             await updateGlobalValue(kSamplerInstanceGlobalValueName, instance);
           }
           await updatePluginTitle(instance);
-          finalDataContextName = await ensureDataContext(instance);
+          const finalDataContextName = await ensureDataContext(instance);
           setGlobalState(draft => {
             draft.instance = instance;
             draft.dataContextName = finalDataContextName;
           });
-        });
+        }).catch(e => console.error(e));
       } else {
-        finalDataContextName = await ensureDataContext(newGlobalState.instance);
+        const finalDataContextName = await ensureDataContext(newGlobalState.instance);
         await updatePluginTitle(newGlobalState.instance);
+        setGlobalState(draft => {
+          draft.dataContextName = finalDataContextName;
+        });
       }
-
-      setGlobalState(draft => {
-        draft.dataContextName = finalDataContextName;
-      });
     };
 
     init();
@@ -222,7 +224,12 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
   }, [globalState]);
 
   useEffect(() => {
-    if (globalState.dataContextName) {
+    // Listeners cannot be removed, so a data context name we have already subscribed to must not be
+    // subscribed to again. The name can return to an earlier value -- init leaves it empty when the
+    // data context could not be found and starting an experiment sets it again -- and every
+    // notification would then be handled once per registration.
+    if (globalState.dataContextName && globalState.dataContextName !== listenedToDataContextName.current) {
+      listenedToDataContextName.current = globalState.dataContextName;
       addDataContextChangeListener(globalState.dataContextName, (msg: any) => {
         if (msg.values.operation === "updateAttributes") {
           msg.values.result.attrIDs.forEach((id: string, i: number) => {

--- a/src/hooks/useGlobalState.tsx
+++ b/src/hooks/useGlobalState.tsx
@@ -176,8 +176,8 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
       // whose column has a different id, which would leave the column's attribute id unrecorded.
       // Everything after this point updates individual properties for the same reason: replacing
       // the whole state would discard whatever findOrCreateDataContext had just written. This is
-      // the only place left that replaces the state wholesale, so nothing may write global state
-      // before it lands -- such a write would be discarded here.
+      // the only place that replaces the state wholesale, so nothing may write global state before
+      // it lands -- such a write would be discarded here.
       setGlobalState(newGlobalState);
 
       const ensureDataContext = async (instance: number) => {

--- a/src/hooks/useGlobalState.tsx
+++ b/src/hooks/useGlobalState.tsx
@@ -172,7 +172,7 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
 
       // Publish the migrated state before touching CODAP. findOrCreateDataContext writes the
       // attribute ids it looks up back into the state it finds, so it has to find this state and
-      // not the placeholder the hook started with — the placeholder is a separate getDefaultState()
+      // not the placeholder the hook started with -- the placeholder is a separate getDefaultState()
       // whose column has a different id, which would leave the column's attribute id unrecorded.
       // Everything after this point updates individual properties for the same reason: replacing
       // the whole state would discard whatever findOrCreateDataContext had just written. This is
@@ -216,7 +216,9 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
       }
     };
 
-    init();
+    // every CODAP request init makes can reject rather than report failure -- on a timeout and on a
+    // closed connection -- and a rejection here would otherwise go unreported
+    init().catch(e => console.error(e));
   }, [setGlobalState]);
 
   useEffect(() => {
@@ -229,7 +231,6 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
     // data context could not be found and starting an experiment sets it again -- and every
     // notification would then be handled once per registration.
     if (globalState.dataContextName && globalState.dataContextName !== listenedToDataContextName.current) {
-      listenedToDataContextName.current = globalState.dataContextName;
       addDataContextChangeListener(globalState.dataContextName, (msg: any) => {
         if (msg.values.operation === "updateAttributes") {
           msg.values.result.attrIDs.forEach((id: string, i: number) => {
@@ -245,6 +246,7 @@ export const useGlobalStateContextValue = (): IGlobalStateContext => {
           });
         }
       });
+      listenedToDataContextName.current = globalState.dataContextName;
     }
 
   }, [globalState.dataContextName, setGlobalState]);

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -145,7 +145,6 @@ export interface IGlobalState {
   attrMap: AttrMap;
   dataContextName: string;
   collectorContextName: string;
-  samplerContext: IDataContext | undefined;
   isRunning: boolean;
   isPaused: boolean;
   speed: Speed;


### PR DESCRIPTION
## Problem

Renaming the output attribute left the old one behind. In a blank document, rename "output" to "choice", press Start, and the case table shows two child attributes: "output" and "choice".

## Root cause

`ColumnHeader.handleNameChange` told CODAP about a rename only when `globalState.samplerContext` was set, and it never was:

- It was set in exactly one place, the create branch of `findOrCreateDataContext`, so a document that was reloaded rather than created never had it at all.
- Even on creation it was discarded immediately: init replaced the whole state afterwards with the copy it had captured before that call, taking `samplerContext` and the attribute ids looked up beside it with it.

So the rename updated the plugin's model and stopped there. The old attribute kept its name in CODAP, and the next run recreated the new one through the missing-attribute path in `findOrCreateDataContext`.

Both whole-state replacements arrived with SAMPLER-78, after SAMPLER-45 was fixed — which fits the observation there that renaming propagated to the case table at the time.

## Changes

- Publish the migrated state before touching CODAP, and update individual properties afterwards, so writes made during initialization survive it.
- Remove `samplerContext`. It carried nothing but a name that `dataContextName` already held and is always set, so its three readers use that instead. Reloaded documents can now rename attributes and hear about renames made in the case table, neither of which they could do before.
- Ask for collections by their localized names rather than by English literals, and ask for a column's attribute from the collection that holds it rather than relying on CODAP resolving a name across the whole data context. See Localization below.
- Keep the column's old name unless CODAP reports the attribute renamed. A request rejects rather than reporting failure when it times out or meets a closed connection, and a rejection means only that we stopped waiting, so what became of the attribute is settled by its id rather than by its name — an attribute that outlives the column that named it can already answer to the name being taken.
- Commit a rename once per edit, however the field is left. Enter blurs and blurring is what commits, so Enter committed twice, and the second pass asked for a name the first had renamed away, read that as a refusal, and put the old name back. Leaving, returning and leaving again did the same. Escape committed the edit it was meant to abandon. Leaving the field without typing sent a real rename to the name already there, writing to the document and adding an undo entry for every column tabbed through.
- Say when a rename does not happen. A refused rename, an attribute that has gone, an empty name, a name de-duplicated to `choice2`, and an edit made while a commit is in flight all changed what the user typed with nothing said. The outcome now goes to a `role="status"` live region beside the header, and the field has an accessible name, matching the pattern `main` uses in the measures panel.
- Create a new column's CODAP attribute outside the state producer, which is meant to be pure and which React makes no promise to invoke exactly once. This call was unreachable until the gate around it started working.
- Report the requests that can fail here through `tryRequest`, which arrived on `main` after this branch started. A rename that is refused, one that never answers, and a create that fails are all reported the one way rather than each growing its own `.catch`.
- Stop rewriting formulas that reference the renamed attribute. Restoring the rename also restored that call, and CODAP v3 has already updated those formulas by the time it runs — so it overwrote correct formulas with the output of the plugin's parser, which drops backticks and quotes and renders references to other attributes as string constants. See the commit for why this leaves CODAP v2 no worse off than it has shipped since SAMPLER-78.

Two build commits ride along: ESLint was merging a config from above the project, which broke `npm run lint` and `npm run build` for a checkout nested inside another one, and `dist/` was not ignored.

## Localization

This PR both repairs and adds to the plugin's localization debt, so it is gathered here rather than spread through the sections above.

**Fixed.** Collections were asked for by the English literals `"items"`, `"samples"` and `"experiments"`. Those names are translated, so outside English every attribute-id lookup matched nothing and no ids were recorded at all — which left the case-table rename listener with nothing to match against, in any locale but one. All collection lookups now go through `getCollectionNames()`, and two tests assert against a non-English collection name rather than one the code under test computes for itself.

**Added.** Five user-facing strings are English rather than `tr()` keys: the field's `aria-label` and the four status messages. That is deliberate and matches what is already there — `custom-select.tsx:107` does the same — for the reason recorded at the TODO in `measures.tsx`: `tr()` renders the key itself when a string is missing, so the POEditor entries have to exist before the keys can be used. A follow-up that adds the entries and converts these together would clear both sites at once.

**Still broken, pre-existing.** Reopening a document in a locale other than the one that created it throws. The collections carry the names of the locale that made them, so looking them up under the current locale's names finds nothing, and the failure surfaces as a `TypeError` that rejects `init`. Not worsened here, and worth its own ticket.

## Not addressed

- `untilFormula` and device transition formulas still keep the old name after a rename. An until formula written as `output = "a"` silently stops matching.
- SAMPLER-45's formula rewriting is gone for CODAP v2. Doing it safely needs to parse formulas the way CODAP parses them rather than approximating it in the plugin.
- A CODAP-side bug: renaming an attribute in a formula that also contains a string constant can move the quoting onto the wrong token.
- `deleteAll` passes an attribute name where a collection name belongs. Nothing calls it.

## Verification

90 tests over 10 suites with `main` merged in, around half of them arriving with it.

New here: a rename reaches CODAP under a non-English collection name, and asks for the attribute from the collection that holds it; the column keeps its old name when CODAP refuses, when the request never answers, when the attribute has gone, and when the new name turns out to belong to some other attribute; it takes the new name when a rename that stopped answering turns out to have happened; one commit per edit through Enter, through leaving and returning, and none at all through Escape or through leaving an unchanged name; the failure message and the field's accessible name; a commit that outlives the column it was opened on, or the entry it renames; the attribute ids looked up during initialization, in a new document and a reloaded one; and adding a column creates its attribute right away, reports a refusal, and survives a create that never answers.

Every guard added in review is mutation-checked: removing it fails a test.

Checked by hand in CODAP v3 across all of the field paths — Enter, Escape, leaving and returning, reload-then-rename, two columns, and renaming from the case table side — as well as a measure referencing two columns staying correct across consecutive renames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
