### PR TITLE
build: authenticate the deploys with OIDC rather than stored keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
       - build_test
       - cypress
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -73,13 +77,15 @@ jobs:
           # skip installing cypress since it isn't needed for just building
           # This decreases the deploy time quite a bit
           CYPRESS_INSTALL_BINARY: 0
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/sampler
+          aws-region: us-east-1
       - uses: concord-consortium/s3-deploy-action@v1
         id: s3-deploy
         with:
           bucket: models-resources
           prefix: sampler
-          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           deployRunUrl: https://codap3.concord.org/branch/main/?di=https://sampler.concord.org/__deployPath__/
           # Parameters to GHActions have to be strings, so a regular yaml array cannot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
     steps:
       - uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,15 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/sampler
+          aws-region: us-east-1
       - run: >
           aws s3 cp
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ github.event.inputs.version }}/${{ env.SRC_FILE }}
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/${{ env.DEST_FILE }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1


### PR DESCRIPTION
Moves both deploy workflows off stored AWS access keys and onto OIDC, matching the pattern already
running in `ocean-explorer` and `starter-projects`.

This is deliberately separate from, and ahead of, the 1.0.5 release PR. Two reasons:

- `ci.yml`'s `s3-deploy` job runs on every push, so this PR's own branch build proves that half.
  `release.yml` is `workflow_dispatch` only and no PR can exercise it — it would otherwise run for
  the very first time at the moment we promote 1.0.5.
- There is a free way to prove `release.yml`, but only until 1.0.5 ships. Dispatching it with
  `v1.0.4` copies `version/v1.0.4/index-top.html` over the top-level `index.html`, and those two
  objects are currently byte-identical (`sha256 dc06ee44e508fed2646876df667aecab2ca62aa03dcb7e4769aeb61d9ff6a3d6`).
  So it exercises the whole credential path against production while changing nothing. Once 1.0.5 is
  released, that same dispatch would roll production back to 1.0.4.

Keeping the auth change out of the release PR also keeps attribution clean: a deploy failure there
would otherwise be ambiguous between the TypeScript toolchain bump and this.

## The role

Created with `starter-projects`' `scripts/create-deploy-role.sh sampler`, after
concord-consortium/starter-projects#93 merged. That ordering mattered — the previous version of the
script hardcoded the legacy OIDC subject claim, which would have produced a role needing migration
the moment sampler was opted in to immutable claims.

`arn:aws:iam::612297603577:role/sampler` trusts both formats, each scoped to this repository:

```
repo:concord-consortium@319219/sampler@731318186:*
repo:concord-consortium/sampler:*
```

GitHub currently reports it will send the legacy form for sampler (`use_immutable_subject: false`),
which is expected for a repo created in 2023.

The role is tagged `RepoName=sampler` and carries only the shared `S3-deploy-by-role-tag` managed
policy. That tag is load-bearing: the policy grants writes to
`arn:aws:s3:::models-resources/${aws:PrincipalTag/RepoName}/*`, so the role can write to
`models-resources/sampler/*` and nowhere else. Sampler deploys only to `models-resources`, so it
needs no additional inline policy.

## On the permissions blocks

Adding an explicit `permissions` block narrows `GITHUB_TOKEN` rather than widening it, so each job
lists only what it needs.

`ci.yml`'s `s3-deploy` gets `id-token: write` to request the OIDC token, `contents: read` because it
runs `actions/checkout`, and `deployments: write`, which `s3-deploy-action` uses to record the
deployment. That matches the block proven in `ocean-explorer`, which drives the same action with the
same inputs.

`release.yml` gets `id-token: write` alone. Copilot pointed out that the release job never checks out
the repository and makes no repo-scoped API call, so `contents: read` bought it nothing — correct,
and now fixed. Note this makes `release.yml` tighter than the equivalent job in `starter-projects`
and `ocean-explorer`, which both still carry `contents: read`; worth tightening there too, so the
org converges rather than sampler quietly differing.

## Not done here

`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are left in the repository's secrets. They are no
longer referenced by any workflow, but leaving them until OIDC has carried a real release keeps
rollback to a one-line revert. Deleting them is a follow-up once 1.0.5 is out.

## Verification

- [ ] This branch's `S3 Deploy` job succeeds, proving `ci.yml` authenticates via OIDC
- [ ] After merge, dispatch `Release` with `v1.0.4` and confirm it succeeds and that the top-level
      `index.html` checksum is unchanged

